### PR TITLE
chore: dynamic versioning and tightened dependency bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           - gds-framework
           - gds-viz
           - gds-games
+          - gds-stockflow
+          - gds-control
           - gds-examples
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## gds-framework v0.2.3
+
+- Add `StructuralWiring` to public API (compiler intermediate for domain DSL wiring emitters)
+- Switch to dynamic versioning — `__version__` in `__init__.py` is the single source of truth
+- Tighten `gds-framework>=0.2.3` lower bound across all dependent packages
+
+## gds-games v0.2.0
+
+- Add canonical bridge (`compile_pattern_to_spec`) — projects OGS patterns to `GDSSpec`
+- Add view stratification architecture
+- Require `gds-framework>=0.2.3`
+
+## gds-stockflow v0.1.0
+
+- Initial release — declarative stock-flow DSL over GDS semantics
+
+## gds-control v0.1.0
+
+- Initial release — state-space control DSL over GDS semantics
+
+## gds-viz v0.1.2
+
+- Mermaid renderers for structural, canonical, architecture, parameter, and traceability views

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,5 +146,6 @@ Both use the pluggable pattern: `Callable[[T], list[Finding]]`.
 - Tags (`Tagged` mixin) are inert — stripped at compile time, never affect verification
 - Parameters (Θ) are structural metadata — GDS never assigns values or binds them
 - `GDSSpec.collect()` type-dispatches TypeDef/Space/Entity/Block/ParameterDef; SpecWiring stays explicit via `register_wiring()`
+- **Versioning**: `__version__` in each package's `__init__.py` is the single source of truth — `pyproject.toml` reads it via `dynamic = ["version"]` + `[tool.hatch.version]`. When bumping a version, only edit `__init__.py`. When a package starts using a new gds-framework API, bump its `gds-framework>=` lower bound in the same change.
 - Each package published independently to PyPI via tag-based workflow (`gds-framework/v0.3.1`)
 - Per-package CLAUDE.md files contain package-specific architecture details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Setup
+
+```bash
+uv sync --all-packages
+```
+
+## Tests
+
+```bash
+# Per-package (preferred — avoids module name collisions)
+uv run --package gds-framework pytest packages/gds-framework/tests -v
+uv run --package gds-games pytest packages/gds-games/tests -v
+
+# Lint
+uv run ruff check packages/
+uv run ruff format --check packages/
+```
+
+## Versioning
+
+Each package's `__init__.py` owns its version via `__version__`. The `pyproject.toml` reads it dynamically — never edit the version there.
+
+To bump a version, edit `__version__` in the package's `__init__.py`.
+
+When a package starts using a new `gds-framework` API, bump the `gds-framework>=` lower bound in that package's `pyproject.toml` in the same change.
+
+## Releases
+
+Packages are published independently via tag-based CI. Tag format: `<package>/v<version>` (e.g., `gds-framework/v0.2.3`).

--- a/packages/gds-control/pyproject.toml
+++ b/packages/gds-control/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gds-control"
-version = "0.1.0"
+dynamic = ["version"]
 description = "State-space control DSL over GDS semantics — control theory with formal guarantees"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2",
+    "gds-framework>=0.2.3",
     "pydantic>=2.10",
 ]
 
@@ -45,6 +45,9 @@ Documentation = "https://blockscience.github.io/gds-core"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "gds_control/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["gds_control"]

--- a/packages/gds-examples/pyproject.toml
+++ b/packages/gds-examples/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "gds-framework>=0.2.0",
+    "gds-framework>=0.2.3",
     "gds-viz>=0.1.0",
 ]
 

--- a/packages/gds-framework/gds/__init__.py
+++ b/packages/gds-framework/gds/__init__.py
@@ -6,7 +6,7 @@ cybernetics (Ghani, Hedges et al.) into a single, dependency-light
 Python framework.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"
 
 # ── Composition algebra ─────────────────────────────────────
 from gds.blocks.base import AtomicBlock, Block

--- a/packages/gds-framework/pyproject.toml
+++ b/packages/gds-framework/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gds-framework"
-version = "0.2.2"
+dynamic = ["version"]
 description = "Generalized Dynamical Systems — typed compositional specifications for complex systems"
 readme = "README.md"
 license = "Apache-2.0"
@@ -46,6 +46,9 @@ Documentation = "https://blockscience.github.io/gds-core"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "gds/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["gds"]

--- a/packages/gds-games/ogs/__init__.py
+++ b/packages/gds-games/ogs/__init__.py
@@ -1,5 +1,7 @@
 """Open Games — Typed DSL for Compositional Game Theory."""
 
+__version__ = "0.2.0"
+
 from ogs.dsl.base import OpenGame
 from ogs.dsl.compile import compile_to_ir
 from ogs.dsl.spec_bridge import compile_pattern_to_spec

--- a/packages/gds-games/pyproject.toml
+++ b/packages/gds-games/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gds-games"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Typed DSL for Compositional Game Theory — define, verify, and report on open game patterns"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.1",
+    "gds-framework>=0.2.3",
     "pydantic>=2.10",
     "typer>=0.15",
     "jinja2>=3.1",
@@ -52,6 +52,9 @@ Documentation = "https://blockscience.github.io/gds-core"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "ogs/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["ogs"]

--- a/packages/gds-stockflow/pyproject.toml
+++ b/packages/gds-stockflow/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gds-stockflow"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Declarative stock-flow DSL over GDS semantics — system dynamics with formal guarantees"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2",
+    "gds-framework>=0.2.3",
     "pydantic>=2.10",
 ]
 
@@ -45,6 +45,9 @@ Documentation = "https://blockscience.github.io/gds-core"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "stockflow/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["stockflow"]

--- a/packages/gds-viz/gds_viz/__init__.py
+++ b/packages/gds-viz/gds_viz/__init__.py
@@ -1,5 +1,7 @@
 """Visualization utilities for GDS specifications."""
 
+__version__ = "0.1.2"
+
 from gds_viz._styles import MermaidTheme
 from gds_viz.architecture import spec_to_mermaid
 from gds_viz.canonical import canonical_to_mermaid

--- a/packages/gds-viz/pyproject.toml
+++ b/packages/gds-viz/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gds-viz"
-version = "0.1.2"
+dynamic = ["version"]
 description = "Mermaid diagram renderers for gds-framework specifications"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.0",
+    "gds-framework>=0.2.3",
 ]
 
 [project.urls]
@@ -41,6 +41,9 @@ Documentation = "https://blockscience.github.io/gds-core"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "gds_viz/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["gds_viz"]


### PR DESCRIPTION
## Summary

- Switch all packages to hatchling dynamic versioning — `__version__` in `__init__.py` is the single source of truth, eliminating drift between `pyproject.toml` and Python source
- Tighten `gds-framework>=0.2.3` lower bound across all dependent packages to prevent `StructuralWiring` import failures on PyPI
- Bump gds-framework to 0.2.3
- Add CI test matrix coverage for gds-stockflow and gds-control
- Add CHANGELOG.md and CONTRIBUTING.md

## Test plan

- [x] All 1,159 tests pass across 6 packages
- [x] `ruff check` and `ruff format --check` pass
- [x] `uv build --package gds-framework` produces `gds_framework-0.2.3` wheel
- [x] `uv sync --all-packages` resolves correctly with dynamic versions