### PR TITLE
ci: add test coverage enforcement to all library packages

### DIFF
--- a/packages/gds-control/pyproject.toml
+++ b/packages/gds-control/pyproject.toml
@@ -54,6 +54,19 @@ packages = ["gds_control"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--import-mode=importlib --cov=gds_control --cov-report=term-missing --no-header -q"
+
+[tool.coverage.run]
+source = ["gds_control"]
+omit = ["gds_control/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]
 
 [tool.ruff.lint]
 ignore = [
@@ -65,5 +78,6 @@ ignore = [
 [dependency-groups]
 dev = [
     "pytest>=9.0",
+    "pytest-cov>=6.0",
     "ruff>=0.8",
 ]

--- a/packages/gds-games/pyproject.toml
+++ b/packages/gds-games/pyproject.toml
@@ -61,6 +61,19 @@ packages = ["ogs"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--import-mode=importlib --cov=ogs --cov-report=term-missing --no-header -q"
+
+[tool.coverage.run]
+source = ["ogs"]
+omit = ["ogs/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]
 
 [tool.ruff.lint]
 ignore = [
@@ -80,5 +93,6 @@ dev = [
     "mypy>=1.19.1",
     "pyright>=1.1.408",
     "pytest>=9.0.2",
+    "pytest-cov>=6.0",
     "ruff>=0.8",
 ]

--- a/packages/gds-stockflow/pyproject.toml
+++ b/packages/gds-stockflow/pyproject.toml
@@ -54,6 +54,19 @@ packages = ["stockflow"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--import-mode=importlib --cov=stockflow --cov-report=term-missing --no-header -q"
+
+[tool.coverage.run]
+source = ["stockflow"]
+omit = ["stockflow/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]
 
 [tool.ruff.lint]
 ignore = [
@@ -65,5 +78,6 @@ ignore = [
 [dependency-groups]
 dev = [
     "pytest>=9.0",
+    "pytest-cov>=6.0",
     "ruff>=0.8",
 ]

--- a/packages/gds-viz/pyproject.toml
+++ b/packages/gds-viz/pyproject.toml
@@ -53,11 +53,25 @@ gds-framework = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--import-mode=importlib --cov=gds_viz --cov-report=term-missing --no-header -q"
+
+[tool.coverage.run]
+source = ["gds_viz"]
+omit = ["gds_viz/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]
 
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",
     "pyright>=1.1.408",
     "pytest>=8.0",
+    "pytest-cov>=6.0",
     "ruff>=0.8",
 ]


### PR DESCRIPTION
## Summary

- Adds `pytest-cov>=6.0` to dev dependencies for gds-viz, gds-games, gds-stockflow, and gds-control
- Configures 80% coverage threshold (matching gds-framework) for all four packages
- Coverage reports automatically via pytest addopts — no CI workflow changes needed
- Skips gds-examples (tutorial package, not a library)

## Package coverage config

| Package | Source | Threshold |
|---------|--------|-----------|
| gds-framework | `gds` | 80% (existing) |
| gds-viz | `gds_viz` | 80% (new) |
| gds-games | `ogs` | 80% (new) |
| gds-stockflow | `stockflow` | 80% (new) |
| gds-control | `gds_control` | 80% (new) |

## Test plan

- [ ] CI tests pass for all packages
- [ ] Coverage reports appear in test output
- [ ] All packages meet the 80% threshold