### PR TITLE
docs: integrate guides into mkdocs documentation site

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,438 @@
+# Getting Started: Build Your First Model
+
+A progressive 5-stage tutorial that teaches GDS fundamentals using a **thermostat control system** as the running example. Each stage builds on the previous one, introducing new concepts incrementally.
+
+## Prerequisites
+
+- Python 3.12+
+- `gds-framework`, `gds-viz`, and `gds-control` installed (`uv sync --all-packages` from the repo root)
+
+## Learning Path
+
+| Stage | Concepts |
+|-------|----------|
+| 1. Minimal Model | Entity, BoundaryAction, Mechanism, `>>` composition, GDSSpec |
+| 2. Feedback | Policy, `.loop()` temporal composition, parameters |
+| 3. DSL Shortcut | gds-control DSL: ControlModel, compile_model, compile_to_system |
+| 4. Verification & Viz | Generic checks (G-001..G-006), semantic checks, Mermaid visualization |
+| 5. Query API | SpecQuery: parameter influence, entity updates, causal chains |
+
+---
+
+## Stage 1 -- Minimal Model
+
+The simplest possible GDS model: a **heater** (BoundaryAction) warms a **room** (Entity with one state variable). Two blocks composed with `>>`.
+
+- **BoundaryAction**: exogenous input -- no `forward_in` ports
+- **Mechanism**: state update -- writes to entity variables, no backward ports
+- **`>>`**: sequential composition via token-matched port wiring
+
+### Types and Entity
+
+```python
+from gds.types.typedef import TypeDef
+from gds.state import Entity, StateVariable
+
+Temperature = TypeDef(
+    name="Temperature",
+    python_type=float,
+    description="Temperature in degrees Celsius",
+)
+
+HeatRate = TypeDef(
+    name="HeatRate",
+    python_type=float,
+    constraint=lambda x: x >= 0,
+    description="Heat input rate (watts)",
+)
+
+room = Entity(
+    name="Room",
+    variables={
+        "temperature": StateVariable(
+            name="temperature",
+            typedef=Temperature,
+            symbol="T",
+            description="Current room temperature",
+        ),
+    },
+    description="The room being heated",
+)
+```
+
+### Blocks and Composition
+
+```python
+from gds.blocks.roles import BoundaryAction, Mechanism
+from gds.types.interface import Interface, port
+
+# BoundaryAction: exogenous heat input
+heater = BoundaryAction(
+    name="Heater",
+    interface=Interface(
+        forward_out=(port("Heat Signal"),),
+    ),
+)
+
+# Mechanism: state update
+update_temperature = Mechanism(
+    name="Update Temperature",
+    interface=Interface(
+        forward_in=(port("Heat Signal"),),
+    ),
+    updates=[("Room", "temperature")],
+)
+
+# Sequential composition -- tokens "heat" and "signal" overlap
+pipeline = heater >> update_temperature
+```
+
+### Structural Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    Heater([Heater]):::boundary
+    Update_Temperature[[Update Temperature]]:::mechanism
+    Heater --Heat Signal--> Update_Temperature
+```
+
+---
+
+## Stage 2 -- Adding Feedback
+
+Extend the minimal model with **observation and control**:
+
+- A **Sensor** (Policy) reads the room temperature
+- A **Controller** (Policy) decides the heat command using a `setpoint` parameter
+- A **TemporalLoop** (`.loop()`) feeds updated temperature back to the sensor across timesteps
+
+New operators: `|` (parallel composition) and `.loop()` (temporal feedback).
+
+### Blocks
+
+```python
+from gds.blocks.roles import BoundaryAction, Mechanism, Policy
+from gds.types.interface import Interface, port
+
+sensor = Policy(
+    name="Sensor",
+    interface=Interface(
+        forward_in=(port("Temperature Reading"),),
+        forward_out=(port("Temperature Observation"),),
+    ),
+)
+
+controller = Policy(
+    name="Controller",
+    interface=Interface(
+        forward_in=(
+            port("Temperature Observation"),
+            port("Heat Signal"),
+        ),
+        forward_out=(port("Heat Command"),),
+    ),
+    params_used=["setpoint"],
+)
+
+update_temperature = Mechanism(
+    name="Update Temperature",
+    interface=Interface(
+        forward_in=(port("Heat Command"),),
+        forward_out=(port("Temperature Reading"),),
+    ),
+    updates=[("Room", "temperature")],
+)
+```
+
+### Composition with Temporal Loop
+
+```python
+from gds.blocks.composition import Wiring
+from gds.ir.models import FlowDirection
+
+input_tier = heater | sensor
+forward_pipeline = input_tier >> controller >> update_temperature
+
+system_with_loop = forward_pipeline.loop(
+    [
+        Wiring(
+            source_block="Update Temperature",
+            source_port="Temperature Reading",
+            target_block="Sensor",
+            target_port="Temperature Reading",
+            direction=FlowDirection.COVARIANT,
+        )
+    ],
+)
+```
+
+### Structural Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    Heater([Heater]):::boundary
+    Sensor[Sensor]:::generic
+    Controller[Controller]:::generic
+    Update_Temperature[Update Temperature]:::generic
+    Heater --Heat Signal--> Controller
+    Sensor --Temperature Observation--> Controller
+    Controller --Heat Command--> Update_Temperature
+    Update_Temperature -.Temperature Reading..-> Sensor
+```
+
+Note the dashed arrow from Update Temperature back to Sensor -- this is the temporal loop (`.loop()`), indicating cross-timestep feedback.
+
+---
+
+## Stage 3 -- DSL Shortcut
+
+Rebuild the same thermostat using the **gds-control** DSL. Declare states, inputs, sensors, and controllers -- the compiler generates all types, spaces, entities, blocks, wirings, and the temporal loop automatically.
+
+**~15 lines of DSL vs ~60 lines of manual GDS construction.**
+
+### ControlModel Declaration
+
+```python
+from gds_control.dsl.compile import compile_model, compile_to_system
+from gds_control.dsl.elements import Controller, Input, Sensor, State
+from gds_control.dsl.model import ControlModel
+
+model = ControlModel(
+    name="Thermostat DSL",
+    states=[
+        State(name="temperature", initial=20.0),
+    ],
+    inputs=[
+        Input(name="heater"),
+    ],
+    sensors=[
+        Sensor(name="temp_sensor", observes=["temperature"]),
+    ],
+    controllers=[
+        Controller(
+            name="thermo",
+            reads=["temp_sensor", "heater"],
+            drives=["temperature"],
+        ),
+    ],
+    description="Thermostat built with the gds-control DSL",
+)
+
+spec = compile_model(model)       # -> GDSSpec
+system = compile_to_system(model)  # -> SystemIR
+```
+
+### DSL Element to GDS Role Mapping
+
+| DSL Element | GDS Role |
+|-------------|----------|
+| `State("temperature")` | Mechanism + Entity |
+| `Input("heater")` | BoundaryAction |
+| `Sensor("temp_sensor")` | Policy (observer) |
+| `Controller("thermo")` | Policy (decision logic) |
+
+### Canonical Decomposition
+
+The canonical projection separates the system into the formal `h = f . g` form:
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    X_t(["X_t<br/>value"]):::state
+    X_next(["X_{t+1}<br/>value"]):::state
+    Theta{{"Θ<br/>heater"}}:::param
+    subgraph U ["Boundary (U)"]
+        heater[heater]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        temp_sensor[temp_sensor]:::policy
+        thermo[thermo]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        temperature_Dynamics[temperature Dynamics]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    temperature_Dynamics -.-> |temperature.value| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+---
+
+## Stage 4 -- Verification & Visualization
+
+GDS provides two layers of verification:
+
+1. **Generic checks (G-001..G-006)** on `SystemIR` -- structural topology
+2. **Semantic checks (SC-001..SC-007)** on `GDSSpec` -- domain properties
+
+Plus three Mermaid diagram views of the compiled system.
+
+### Running Verification
+
+```python
+from gds.verification.engine import verify
+from gds.verification.generic_checks import (
+    check_g001_domain_codomain_matching,
+    check_g003_direction_consistency,
+    check_g004_dangling_wirings,
+    check_g005_sequential_type_compatibility,
+    check_g006_covariant_acyclicity,
+)
+
+report = verify(system, checks=[
+    check_g001_domain_codomain_matching,
+    check_g003_direction_consistency,
+    check_g004_dangling_wirings,
+    check_g005_sequential_type_compatibility,
+    check_g006_covariant_acyclicity,
+])
+
+for finding in report.findings:
+    status = "PASS" if finding.passed else "FAIL"
+    print(f"[{finding.check_id}] {status}: {finding.message}")
+```
+
+### Three Visualization Views
+
+=== "Structural"
+
+    The compiled block graph showing blocks as nodes and wirings as arrows.
+
+    ```mermaid
+    %%{init:{"theme":"neutral"}}%%
+    flowchart TD
+        classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+        classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+        heater([heater]):::boundary
+        temp_sensor[temp_sensor]:::generic
+        thermo[thermo]:::generic
+        temperature_Dynamics[temperature Dynamics]:::generic
+        heater --heater Reference--> thermo
+        temp_sensor --temp_sensor Measurement--> thermo
+        thermo --thermo Control--> temperature_Dynamics
+        temperature_Dynamics -.temperature State..-> temp_sensor
+    ```
+
+=== "Architecture"
+
+    Blocks grouped by GDS role: Boundary (U), Policy (g), Mechanism (f).
+
+    ```mermaid
+    %%{init:{"theme":"neutral"}}%%
+    flowchart TD
+        classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+        classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+        classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+        classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+        subgraph boundary ["Boundary (U)"]
+            heater([heater]):::boundary
+        end
+        subgraph policy ["Policy (g)"]
+            temp_sensor[temp_sensor]:::policy
+            thermo[thermo]:::policy
+        end
+        subgraph mechanism ["Mechanism (f)"]
+            temperature_Dynamics[[temperature Dynamics]]:::mechanism
+        end
+        entity_temperature[("temperature<br/>value")]:::entity
+        temperature_Dynamics -.-> entity_temperature
+        thermo --ControlSpace--> temperature_Dynamics
+        style boundary fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+        style policy fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+        style mechanism fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+    ```
+
+=== "Canonical"
+
+    The formal `h = f . g` decomposition diagram (same as Stage 3 above).
+
+---
+
+## Stage 5 -- Query API
+
+`SpecQuery` provides static analysis over a `GDSSpec` without running any simulation. It answers structural questions about information flow, parameter influence, and causal chains.
+
+### Usage
+
+```python
+from gds.query import SpecQuery
+
+query = SpecQuery(spec)
+
+# Which blocks does each parameter affect?
+query.param_to_blocks()
+# -> {'heater': ['heater']}
+
+# Which mechanisms update each entity variable?
+query.entity_update_map()
+# -> {'temperature': {'value': ['temperature Dynamics']}}
+
+# Group blocks by GDS role
+query.blocks_by_kind()
+# -> {'boundary': ['heater'], 'policy': ['temp_sensor', 'thermo'],
+#     'mechanism': ['temperature Dynamics'], ...}
+
+# Which blocks can transitively affect temperature.value?
+query.blocks_affecting("temperature", "value")
+# -> ['temperature Dynamics', 'thermo', 'temp_sensor', 'heater']
+
+# Full block-to-block dependency DAG
+query.dependency_graph()
+```
+
+---
+
+## Summary
+
+You have built a complete GDS specification for a thermostat system, progressing through five stages:
+
+1. **Minimal model** -- types, entity, two blocks, sequential composition
+2. **Feedback** -- policies, parameters, temporal loop
+3. **DSL** -- same system in 15 lines with `gds-control`
+4. **Verification** -- structural and semantic checks, three diagram views
+5. **Query** -- static analysis of parameter influence and causal chains
+
+From here, explore the [example models](../examples/index.md) or the [Rosetta Stone](rosetta-stone.md) guide to see the same system through different DSL lenses.
+
+## Running Interactively
+
+The guide includes a [marimo notebook](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/notebook.py) for interactive exploration:
+
+```bash
+uv run marimo run packages/gds-examples/guides/getting_started/notebook.py
+```
+
+Run the test suite:
+
+```bash
+uv run --package gds-examples pytest packages/gds-examples/guides/getting_started/ -v
+```
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| [`stage1_minimal.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/stage1_minimal.py) | Minimal heater model |
+| [`stage2_feedback.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/stage2_feedback.py) | Feedback loop with policies |
+| [`stage3_dsl.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/stage3_dsl.py) | gds-control DSL version |
+| [`stage4_verify_viz.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/stage4_verify_viz.py) | Verification and visualization |
+| [`stage5_query.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/stage5_query.py) | SpecQuery API |
+| [`notebook.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/getting_started/notebook.py) | Interactive marimo notebook |

--- a/docs/guides/rosetta-stone.md
+++ b/docs/guides/rosetta-stone.md
@@ -1,0 +1,338 @@
+# Rosetta Stone: Cross-Domain Comparison
+
+Three views of the same **resource pool** problem, each compiled to a GDS canonical form. This guide demonstrates the central insight of GDS: the same composition algebra underlies stock-flow dynamics, feedback control, and strategic game theory.
+
+## The Resource Pool Scenario
+
+A shared resource pool (water reservoir, inventory, commons) that agents interact with through supply, consumption, or extraction. The same real-world system is modeled through three different DSL lenses.
+
+## Canonical Spectrum
+
+All three views compile to `GDSSpec` and project to the canonical `h = f . g` decomposition:
+
+```
+View             |X|  |U|  |g|  |f|  Form                 Character
+----------------------------------------------------------------------
+Stock-Flow         1    2    3    1  h_theta = f . g      Dynamical
+Control            1    1    2    1  h_theta = f . g      Dynamical
+Game Theory        0    1    3    0  h = g                Strategic
+```
+
+Key insight: each DSL decomposes the problem differently:
+
+- **Stock-Flow**: State X is the resource level, updated by net flow rates. Two exogenous parameters (supply rate, consumption rate) drive the dynamics.
+- **Control**: State X is the resource level, regulated by a feedback controller that tracks an exogenous reference setpoint.
+- **Game Theory**: No state -- pure strategic interaction. Two agents simultaneously choose extraction amounts; a payoff function determines the outcome.
+
+---
+
+## Stock-Flow View
+
+Models the resource pool as a stock that accumulates via a supply inflow and depletes via a consumption outflow. An auxiliary computes the net rate from supply and consumption parameters.
+
+**Canonical facts:** |X|=1, |U|=2, |g|=3, |f|=1, character = Dynamical
+
+### StockFlowModel Declaration
+
+```python
+from stockflow.dsl.compile import compile_model, compile_to_system
+from stockflow.dsl.elements import Auxiliary, Converter, Flow, Stock
+from stockflow.dsl.model import StockFlowModel
+
+model = StockFlowModel(
+    name="Resource Pool (Stock-Flow)",
+    stocks=[
+        Stock(name="ResourceLevel", initial=100.0, non_negative=True),
+    ],
+    flows=[
+        Flow(name="supply", target="ResourceLevel"),
+        Flow(name="consumption", source="ResourceLevel"),
+    ],
+    auxiliaries=[
+        Auxiliary(name="net_rate", inputs=["supply_rate", "consumption_rate"]),
+    ],
+    converters=[
+        Converter(name="supply_rate"),
+        Converter(name="consumption_rate"),
+    ],
+)
+```
+
+### Structural Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    supply_rate([supply_rate]):::boundary
+    consumption_rate([consumption_rate]):::boundary
+    net_rate[net_rate]:::generic
+    supply([supply]):::boundary
+    consumption([consumption]):::boundary
+    ResourceLevel_Accumulation[ResourceLevel Accumulation]:::generic
+    supply_rate --supply_rate Signal--> net_rate
+    consumption_rate --consumption_rate Signal--> net_rate
+    supply --supply Rate--> ResourceLevel_Accumulation
+    consumption --consumption Rate--> ResourceLevel_Accumulation
+```
+
+### Canonical Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    X_t(["X_t<br/>level"]):::state
+    X_next(["X_{t+1}<br/>level"]):::state
+    Theta{{"Θ<br/>supply_rate, consumption_rate"}}:::param
+    subgraph U ["Boundary (U)"]
+        supply_rate[supply_rate]:::boundary
+        consumption_rate[consumption_rate]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        net_rate[net_rate]:::policy
+        supply[supply]:::policy
+        consumption[consumption]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        ResourceLevel_Accumulation[ResourceLevel Accumulation]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    ResourceLevel_Accumulation -.-> |ResourceLevel.level| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+---
+
+## Control View
+
+Models the same resource pool as a feedback control system. The resource level is a plant state, a target reference level is an exogenous input, and a controller adjusts the supply rate to track the target.
+
+**Canonical facts:** |X|=1, |U|=1, |g|=2, |f|=1, character = Dynamical
+
+### ControlModel Declaration
+
+```python
+from gds_control.dsl.compile import compile_model, compile_to_system
+from gds_control.dsl.elements import Controller, Input, Sensor, State
+from gds_control.dsl.model import ControlModel
+
+model = ControlModel(
+    name="Resource Pool (Control)",
+    states=[
+        State(name="resource_level", initial=100.0),
+    ],
+    inputs=[
+        Input(name="target_level"),
+    ],
+    sensors=[
+        Sensor(name="level_sensor", observes=["resource_level"]),
+    ],
+    controllers=[
+        Controller(
+            name="supply_controller",
+            reads=["level_sensor", "target_level"],
+            drives=["resource_level"],
+        ),
+    ],
+)
+```
+
+### Structural Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    target_level([target_level]):::boundary
+    level_sensor[level_sensor]:::generic
+    supply_controller[supply_controller]:::generic
+    resource_level_Dynamics[resource_level Dynamics]:::generic
+    target_level --target_level Reference--> supply_controller
+    level_sensor --level_sensor Measurement--> supply_controller
+    supply_controller --supply_controller Control--> resource_level_Dynamics
+    resource_level_Dynamics -.resource_level State..-> level_sensor
+```
+
+### Canonical Diagram
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    X_t(["X_t<br/>value"]):::state
+    X_next(["X_{t+1}<br/>value"]):::state
+    Theta{{"Θ<br/>target_level"}}:::param
+    subgraph U ["Boundary (U)"]
+        target_level[target_level]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        level_sensor[level_sensor]:::policy
+        supply_controller[supply_controller]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        resource_level_Dynamics[resource_level Dynamics]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    resource_level_Dynamics -.-> |resource_level.value| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+---
+
+## Game Theory View
+
+Models the resource pool as a two-player extraction game using the OGS (Open Games) DSL. Two agents simultaneously decide how much to extract from a shared resource. Each agent's payoff depends on how much resource remains after both extractions -- a classic common-pool resource dilemma.
+
+This is a stateless strategic interaction: no persistent state updates, pure policy computation.
+
+**Canonical facts:** |X|=0, |U|=1, |g|=3, |f|=0, character = Strategic
+
+### OGS Pattern Declaration
+
+```python
+from ogs.dsl.games import CovariantFunction, DecisionGame
+from ogs.dsl.pattern import Pattern, PatternInput
+from ogs.dsl.types import InputType, Signature, port
+
+resource_input = PatternInput(
+    name="Resource Availability",
+    input_type=InputType.RESOURCE,
+    schema_hint="float >= 0",
+    target_game="Agent 1 Extraction",
+    flow_label="Resource Signal",
+)
+
+agent1 = DecisionGame(
+    name="Agent 1 Extraction",
+    signature=Signature(
+        x=(port("Resource Signal"),),
+        y=(port("Agent 1 Decision"),),
+        r=(port("Agent 1 Payoff"),),
+    ),
+    logic="Choose extraction amount based on resource availability",
+)
+
+agent2 = DecisionGame(
+    name="Agent 2 Extraction",
+    signature=Signature(
+        x=(port("Resource Signal"),),
+        y=(port("Agent 2 Decision"),),
+        r=(port("Agent 2 Payoff"),),
+    ),
+    logic="Choose extraction amount based on resource availability",
+)
+
+payoff = CovariantFunction(
+    name="Payoff Computation",
+    signature=Signature(
+        x=(port("Agent 1 Decision"), port("Agent 2 Decision")),
+        y=(port("Allocation Result"),),
+    ),
+    logic="Compute payoffs based on total extraction vs available resource",
+)
+
+# Compose: agents decide in parallel, then payoff computation
+game_tree = (agent1 | agent2) >> payoff
+
+pattern = Pattern(
+    name="Resource Pool (Game)",
+    game=game_tree,
+    inputs=[resource_input],
+)
+```
+
+### Canonical Diagram
+
+Since there are no mechanisms (|f|=0), the canonical form reduces to **h = g** -- pure policy.
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    X_t(["X_t"]):::state
+    X_next(["X_{t+1}"]):::state
+    subgraph U ["Boundary (U)"]
+        Resource_Availability[Resource Availability]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        Agent_1_Extraction[Agent 1 Extraction]:::policy
+        Agent_2_Extraction[Agent 2 Extraction]:::policy
+        Payoff_Computation[Payoff Computation]:::policy
+    end
+    X_t --> U
+    U --> g
+    g --> X_next
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+```
+
+---
+
+## Cross-Domain Comparison
+
+The comparison table built programmatically by `comparison.py` reveals the unified transition calculus:
+
+```
+h_theta : X -> X    where h = f . g
+```
+
+- When |f| > 0 and |g| > 0: **Dynamical** system (stock-flow, control)
+- When |f| = 0 and |g| > 0: **Strategic** system (game theory)
+- When |g| = 0 and |f| > 0: **Autonomous** system (no policy)
+
+This is the "Rosetta Stone" -- the same mathematical structure expressed in different domain languages, all grounded in GDS theory.
+
+```python
+from guides.rosetta.comparison import canonical_spectrum_table
+
+print(canonical_spectrum_table())
+```
+
+## Running Interactively
+
+The guide includes a [marimo notebook](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/notebook.py) for interactive exploration with live Mermaid rendering and dropdown selectors:
+
+```bash
+uv run marimo run packages/gds-examples/guides/rosetta/notebook.py
+```
+
+Run the test suite:
+
+```bash
+uv run --package gds-examples pytest packages/gds-examples/guides/rosetta/ -v
+```
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| [`stockflow_view.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/stockflow_view.py) | Stock-flow DSL model |
+| [`control_view.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/control_view.py) | Control DSL model |
+| [`game_view.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/game_view.py) | Game theory DSL model |
+| [`comparison.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/comparison.py) | Cross-domain canonical comparison |
+| [`notebook.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/rosetta/notebook.py) | Interactive marimo notebook |

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -1,0 +1,396 @@
+# Verification Guide
+
+A hands-on walkthrough of the three verification layers in GDS, using deliberately broken models to demonstrate what each check catches and how to fix it.
+
+## Three Verification Layers
+
+| Layer | Checks | Operates on | Catches |
+|-------|--------|-------------|---------|
+| **Generic** | G-001..G-006 | `SystemIR` | Structural topology errors |
+| **Semantic** | SC-001..SC-007 | `GDSSpec` | Domain property violations |
+| **Domain** | SF-001..SF-005 | DSL model | DSL-specific errors |
+
+Each layer operates on a different representation, and the layers are complementary: a model can pass all generic checks but fail semantic checks (and vice versa).
+
+---
+
+## Layer 1: Generic Checks (G-series)
+
+Generic checks operate on the compiled `SystemIR` -- the flat block graph with typed wirings. They verify **structural topology** independent of any domain semantics.
+
+### G-004: Dangling Wirings
+
+A wiring references a block that does not exist in the system.
+
+```python
+from gds.ir.models import BlockIR, FlowDirection, SystemIR, WiringIR
+
+system = SystemIR(
+    name="Dangling Wiring Demo",
+    blocks=[
+        BlockIR(name="A", signature=("", "Signal", "", "")),
+        BlockIR(name="B", signature=("Signal", "", "", "")),
+    ],
+    wirings=[
+        WiringIR(
+            source="Ghost",  # does not exist!
+            target="B",
+            label="signal",
+            direction=FlowDirection.COVARIANT,
+        ),
+    ],
+)
+```
+
+```python
+from gds.verification.engine import verify
+from gds.verification.generic_checks import check_g004_dangling_wirings
+
+report = verify(system, checks=[check_g004_dangling_wirings])
+# -> G-004 FAIL: source 'Ghost' unknown
+```
+
+### G-001/G-005: Type Mismatches
+
+Block A outputs `Temperature` but Block B expects `Pressure`. The wiring label does not match either side.
+
+```python
+system = SystemIR(
+    name="Type Mismatch Demo",
+    blocks=[
+        BlockIR(name="A", signature=("", "Temperature", "", "")),
+        BlockIR(name="B", signature=("Pressure", "", "", "")),
+    ],
+    wirings=[
+        WiringIR(
+            source="A", target="B",
+            label="humidity",  # matches neither side
+            direction=FlowDirection.COVARIANT,
+        ),
+    ],
+)
+```
+
+- **G-001** flags: wiring label does not match source out or target in
+- **G-005** flags: type mismatch in sequential composition
+
+### G-006: Covariant Cycles
+
+Three blocks form a cycle via non-temporal covariant wirings -- an algebraic loop that cannot be resolved within a single timestep.
+
+```python
+system = SystemIR(
+    name="Covariant Cycle Demo",
+    blocks=[
+        BlockIR(name="A", signature=("Signal", "Signal", "", "")),
+        BlockIR(name="B", signature=("Signal", "Signal", "", "")),
+        BlockIR(name="C", signature=("Signal", "Signal", "", "")),
+    ],
+    wirings=[
+        WiringIR(source="A", target="B", label="signal",
+                 direction=FlowDirection.COVARIANT),
+        WiringIR(source="B", target="C", label="signal",
+                 direction=FlowDirection.COVARIANT),
+        WiringIR(source="C", target="A", label="signal",
+                 direction=FlowDirection.COVARIANT),
+    ],
+)
+# -> G-006 FAIL: covariant flow graph contains a cycle
+```
+
+### G-003: Direction Contradictions
+
+A wiring marked COVARIANT but also `is_feedback=True` is a contradiction: feedback implies contravariant flow.
+
+```python
+WiringIR(
+    source="A", target="B",
+    label="command",
+    direction=FlowDirection.COVARIANT,
+    is_feedback=True,  # contradiction!
+)
+# -> G-003 FAIL: COVARIANT + is_feedback contradiction
+```
+
+### Fix and Re-verify
+
+The core workflow: build a broken model, run checks, inspect findings, fix errors, re-verify.
+
+```python
+from gds.verification.engine import verify
+from guides.verification.broken_models import (
+    dangling_wiring_system,
+    fixed_pipeline_system,
+)
+
+# Step 1: Broken model
+broken_report = verify(dangling_wiring_system())
+# -> errors >= 1
+
+# Step 2: Fixed model
+fixed_report = verify(fixed_pipeline_system())
+# -> all checks pass, 0 errors
+```
+
+---
+
+## Layer 2: Semantic Checks (SC-series)
+
+Semantic checks operate on `GDSSpec` -- the specification registry with types, entities, blocks, and parameters. They verify **domain properties** like completeness, determinism, and canonical well-formedness.
+
+### SC-001: Orphan State Variables
+
+Entity `Reservoir` has variable `level` but no mechanism updates it.
+
+```python
+from gds.blocks.roles import Policy
+from gds.spec import GDSSpec
+from gds.state import Entity, StateVariable
+from gds.types.interface import Interface, port
+from gds.types.typedef import TypeDef
+
+Count = TypeDef(name="Count", python_type=int, constraint=lambda x: x >= 0)
+
+spec = GDSSpec(name="Orphan State Demo")
+spec.register_type(Count)
+
+reservoir = Entity(
+    name="Reservoir",
+    variables={
+        "level": StateVariable(name="level", typedef=Count, symbol="L"),
+    },
+)
+spec.register_entity(reservoir)
+
+# A policy observes but no mechanism updates the reservoir
+observe = Policy(
+    name="Observe Level",
+    interface=Interface(forward_out=(port("Level Signal"),)),
+)
+spec.register_block(observe)
+```
+
+```python
+from gds.verification.spec_checks import check_completeness
+
+findings = check_completeness(spec)
+# -> SC-001 WARNING: orphan state variable Reservoir.level
+```
+
+### SC-002: Write Conflicts
+
+Two mechanisms both update `Counter.value` within the same wiring -- non-deterministic state transition.
+
+```python
+from gds.blocks.roles import BoundaryAction, Mechanism
+
+inc = Mechanism(
+    name="Increment Counter",
+    interface=Interface(forward_in=(port("Delta Signal"),)),
+    updates=[("Counter", "value")],
+)
+
+dec = Mechanism(
+    name="Decrement Counter",
+    interface=Interface(forward_in=(port("Delta Signal"),)),
+    updates=[("Counter", "value")],  # same variable!
+)
+```
+
+```python
+from gds.verification.spec_checks import check_determinism
+
+findings = check_determinism(spec)
+# -> SC-002 ERROR: write conflict -- Counter.value updated by two mechanisms
+```
+
+### SC-006/SC-007: Empty Canonical Form
+
+A spec with no mechanisms and no entities -- empty state transition and empty state space.
+
+```python
+spec = GDSSpec(name="Empty Canonical Demo")
+spec.register_block(Policy(
+    name="Observer",
+    interface=Interface(
+        forward_in=(port("Input Signal"),),
+        forward_out=(port("Output Signal"),),
+    ),
+))
+```
+
+```python
+from gds.verification.spec_checks import check_canonical_wellformedness
+
+findings = check_canonical_wellformedness(spec)
+# -> SC-006 FAIL: no mechanisms found -- state transition f is empty
+# -> SC-007 FAIL: state space X is empty
+```
+
+---
+
+## Layer 3: Domain Checks (SF-series)
+
+Domain checks operate on the **DSL model** before compilation. They catch errors that only make sense in the domain semantics -- for example, "orphan stock" is meaningless outside stock-flow.
+
+The StockFlow DSL provides SF-001..SF-005, running before GDS compilation for early feedback in domain-native terms.
+
+### SF-001: Orphan Stocks
+
+A stock has no connected flows -- nothing fills or drains it.
+
+```python
+from stockflow.dsl.elements import Flow, Stock
+from stockflow.dsl.model import StockFlowModel
+
+model = StockFlowModel(
+    name="Orphan Stock Demo",
+    stocks=[
+        Stock(name="Active"),
+        Stock(name="Inventory"),  # no flows!
+    ],
+    flows=[
+        Flow(name="Production", target="Active"),
+        Flow(name="Consumption", source="Active"),
+    ],
+)
+```
+
+```python
+from stockflow.verification.checks import check_sf001_orphan_stocks
+
+findings = check_sf001_orphan_stocks(model)
+# -> SF-001 WARNING: Stock 'Inventory' has no connected flows
+```
+
+### SF-003: Auxiliary Cycles
+
+Circular dependency between auxiliaries -- Price depends on Demand, which depends on Price.
+
+```python
+from stockflow.dsl.elements import Auxiliary, Stock
+from stockflow.dsl.model import StockFlowModel
+
+model = StockFlowModel(
+    name="Cyclic Auxiliary Demo",
+    stocks=[Stock(name="Supply")],
+    auxiliaries=[
+        Auxiliary(name="Price", inputs=["Demand"]),
+        Auxiliary(name="Demand", inputs=["Price"]),
+    ],
+)
+```
+
+```python
+from stockflow.verification.checks import check_sf003_auxiliary_acyclicity
+
+findings = check_sf003_auxiliary_acyclicity(model)
+# -> SF-003 ERROR: cycle detected in auxiliary dependency graph
+```
+
+### SF-004: Unused Converters
+
+A converter is declared but no auxiliary reads from it.
+
+```python
+from stockflow.dsl.elements import Auxiliary, Converter, Flow, Stock
+from stockflow.dsl.model import StockFlowModel
+
+model = StockFlowModel(
+    name="Unused Converter Demo",
+    stocks=[Stock(name="Revenue")],
+    flows=[Flow(name="Income", target="Revenue")],
+    auxiliaries=[Auxiliary(name="Growth", inputs=["Revenue"])],
+    converters=[Converter(name="Tax Rate")],  # unused!
+)
+```
+
+```python
+from stockflow.verification.checks import check_sf004_converter_connectivity
+
+findings = check_sf004_converter_connectivity(model)
+# -> SF-004 WARNING: Converter 'Tax Rate' is NOT referenced by any auxiliary
+```
+
+### Combined Domain + GDS Checks
+
+The StockFlow verification engine can run domain checks (SF) **and** generic GDS checks (G) together:
+
+```python
+from stockflow.verification.engine import verify
+
+report = verify(model, include_gds_checks=True)
+
+sf_findings = [f for f in report.findings if f.check_id.startswith("SF-")]
+gds_findings = [f for f in report.findings if f.check_id.startswith("G-")]
+```
+
+---
+
+## Check Reference
+
+### Generic Checks (SystemIR)
+
+| ID | Name | Catches |
+|----|------|---------|
+| G-001 | Domain/codomain matching | Wiring label vs port mismatch |
+| G-002 | Signature completeness | Blocks with no ports |
+| G-003 | Direction consistency | COVARIANT + feedback flag |
+| G-004 | Dangling wirings | References to missing blocks |
+| G-005 | Sequential type compat | Mismatched `>>` port types |
+| G-006 | Covariant acyclicity | Algebraic loops |
+
+### Semantic Checks (GDSSpec)
+
+| ID | Name | Catches |
+|----|------|---------|
+| SC-001 | Completeness | Orphan state variables |
+| SC-002 | Determinism | Write conflicts |
+| SC-003 | Reachability | Unreachable blocks |
+| SC-004 | Type safety | TypeDef violations |
+| SC-005 | Parameter refs | Unregistered params |
+| SC-006 | Canonical f | No mechanisms |
+| SC-007 | Canonical X | No state space |
+
+### Domain Checks (StockFlowModel)
+
+| ID | Name | Catches |
+|----|------|---------|
+| SF-001 | Orphan stocks | Stocks with no flows |
+| SF-003 | Auxiliary cycles | Circular aux deps |
+| SF-004 | Converter connectivity | Unused converters |
+
+### API Pattern
+
+```python
+from gds.verification.engine import verify
+
+system = compile_system(name="My Model", root=pipeline)
+report = verify(system)
+
+for finding in report.findings:
+    print(f"{finding.check_id}: {finding.message}")
+```
+
+## Running Interactively
+
+The guide includes a [marimo notebook](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/verification/notebook.py) with interactive dropdowns for selecting broken models and watching checks in real time:
+
+```bash
+uv run marimo run packages/gds-examples/guides/verification/notebook.py
+```
+
+Run the test suite:
+
+```bash
+uv run --package gds-examples pytest packages/gds-examples/guides/verification/ -v
+```
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| [`broken_models.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/verification/broken_models.py) | Deliberately broken models for each check |
+| [`verification_demo.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/verification/verification_demo.py) | Generic and semantic check demos |
+| [`domain_checks_demo.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/verification/domain_checks_demo.py) | StockFlow domain check demos |
+| [`notebook.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/verification/notebook.py) | Interactive marimo notebook |

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -1,0 +1,227 @@
+# Visualization Guide
+
+A feature showcase for `gds-viz`, demonstrating all 6 view types, 5 built-in Mermaid themes, and cross-DSL visualization. Every diagram renders in GitHub, GitLab, VS Code, Obsidian, and mermaid.live.
+
+## The 6 GDS Views
+
+Every GDS model can be visualized from 6 complementary perspectives. Each view answers a different question about the system's structure.
+
+| # | View | Input | Question Answered |
+|:-:|------|-------|-------------------|
+| 1 | Structural | `SystemIR` | What is the compiled block topology? |
+| 2 | Canonical | `CanonicalGDS` | What is the formal h = f . g decomposition? |
+| 3 | Architecture by Role | `GDSSpec` | How are blocks organized by GDS role? |
+| 4 | Architecture by Domain | `GDSSpec` | How are blocks organized by domain ownership? |
+| 5 | Parameter Influence | `GDSSpec` | If I change a parameter, what is affected? |
+| 6 | Traceability | `GDSSpec` | What could cause this state variable to change? |
+
+### View 1: Structural
+
+The compiled block graph from `SystemIR`. Shows composition topology with role-based shapes and wiring types.
+
+**Shape conventions:**
+
+- Stadium `([...])` = BoundaryAction (exogenous input, no forward_in)
+- Double-bracket `[[...]]` = terminal Mechanism (state sink, no forward_out)
+- Rectangle `[...]` = Policy or other block with both inputs and outputs
+
+**Arrow conventions:**
+
+- Solid arrow `-->` = covariant forward flow
+- Dashed arrow `-.->` = temporal loop (cross-timestep)
+- Thick arrow `==>` = feedback (within-timestep, contravariant)
+
+**API:** `system_to_mermaid(system)`
+
+### View 2: Canonical GDS
+
+The mathematical decomposition: X_t --> U --> g --> f --> X_{t+1}. Shows the abstract dynamical system with state (X), input (U), policy (g), mechanism (f), and parameter space (Theta).
+
+**API:** `canonical_to_mermaid(canonical)`
+
+### View 3: Architecture by Role
+
+Blocks grouped by GDS role: Boundary (U), Policy (g), Mechanism (f). Entity cylinders show which state variables each mechanism writes.
+
+**API:** `spec_to_mermaid(spec)`
+
+### View 4: Architecture by Domain
+
+Blocks grouped by domain tag. Shows organizational ownership of blocks. Blocks without the tag go into "Ungrouped".
+
+**API:** `spec_to_mermaid(spec, group_by="domain")`
+
+### View 5: Parameter Influence
+
+Theta --> blocks --> entities causal map. Answers: "if I change parameter X, which state variables are affected?" Shows parameter hexagons, the blocks they feed, and the entities those blocks transitively update.
+
+**API:** `params_to_mermaid(spec)`
+
+### View 6: Traceability
+
+Backwards trace from one state variable. Answers: "what blocks and parameters could cause this variable to change?" Direct mechanisms get thick arrows, transitive dependencies get normal arrows, and parameter connections get dashed arrows.
+
+**API:** `trace_to_mermaid(spec, entity, variable)`
+
+### Generating All Views
+
+```python
+from gds.canonical import project_canonical
+from gds_viz import (
+    canonical_to_mermaid,
+    params_to_mermaid,
+    spec_to_mermaid,
+    system_to_mermaid,
+    trace_to_mermaid,
+)
+
+# From any model's build functions:
+spec = build_spec()
+system = build_system()
+canonical = project_canonical(spec)
+
+views = {
+    "structural": system_to_mermaid(system),
+    "canonical": canonical_to_mermaid(canonical),
+    "architecture_by_role": spec_to_mermaid(spec),
+    "architecture_by_domain": spec_to_mermaid(spec, group_by="domain"),
+    "parameter_influence": params_to_mermaid(spec),
+    "traceability": trace_to_mermaid(spec, "Susceptible", "count"),
+}
+```
+
+---
+
+## Theme Customization
+
+Every `gds-viz` view function accepts a `theme=` parameter. There are **5 built-in Mermaid themes** that adjust node fills, strokes, text colors, and subgraph backgrounds.
+
+| Theme | Best for |
+|-------|----------|
+| `neutral` | Light backgrounds (GitHub, docs) -- **default** |
+| `default` | Mermaid's blue-toned Material style |
+| `dark` | Dark-mode renderers |
+| `forest` | Green-tinted, earthy |
+| `base` | Minimal chrome, very light |
+
+### Usage
+
+```python
+from gds_viz import system_to_mermaid
+
+# Apply any theme to any view
+mermaid_str = system_to_mermaid(system, theme="dark")
+```
+
+### All Views Support Themes
+
+Themes work with every view function:
+
+```python
+from gds_viz import (
+    system_to_mermaid,
+    canonical_to_mermaid,
+    spec_to_mermaid,
+    params_to_mermaid,
+    trace_to_mermaid,
+)
+
+system_to_mermaid(system, theme="forest")
+canonical_to_mermaid(canonical, theme="dark")
+spec_to_mermaid(spec, theme="base")
+params_to_mermaid(spec, theme="default")
+trace_to_mermaid(spec, "Entity", "variable", theme="neutral")
+```
+
+### Neutral vs Dark Comparison
+
+The two most common choices:
+
+- **Neutral** (default): muted gray canvas with saturated node fills. Best for light-background rendering (GitHub, VS Code light mode, documentation sites).
+- **Dark**: dark canvas with saturated fills and light text. Optimized for dark-mode renderers.
+
+---
+
+## Cross-DSL Views
+
+The `gds-viz` API is **DSL-neutral** -- it operates on `GDSSpec` and `SystemIR`, which every compilation path produces. Regardless of how a model is built (raw GDS blocks, stockflow DSL, control DSL, or games DSL), the same view functions work unchanged.
+
+### Example: Hand-Built vs DSL-Compiled
+
+```python
+# Hand-built model (SIR Epidemic)
+from sir_epidemic.model import build_spec, build_system
+sir_spec = build_spec()
+sir_system = build_system()
+sir_structural = system_to_mermaid(sir_system)
+
+# DSL-compiled model (Double Integrator via gds-control)
+from double_integrator.model import build_spec, build_system
+di_spec = build_spec()
+di_system = build_system()
+di_structural = system_to_mermaid(di_system)
+
+# Same API, same function, different models -- works identically
+```
+
+Both models decompose into the same `h = f . g` structure, but with different dimensionalities. The SIR model has parameters (Theta); the double integrator may not. The visualization layer does not care about the construction path -- it only sees the compiled IR.
+
+### Supported DSL Sources
+
+| Source | Path to GDSSpec | Path to SystemIR |
+|--------|----------------|------------------|
+| Raw GDS | Manual `build_spec()` | `compile_system(name, root)` |
+| gds-stockflow | `stockflow.dsl.compile.compile_model()` | `stockflow.dsl.compile.compile_to_system()` |
+| gds-control | `gds_control.dsl.compile.compile_model()` | `gds_control.dsl.compile.compile_to_system()` |
+| gds-games | `ogs.dsl.spec_bridge.compile_pattern_to_spec()` | via `PatternIR.to_system_ir()` |
+
+---
+
+## API Quick Reference
+
+All functions live in `gds_viz` and return Mermaid strings.
+
+| Function | Input | View |
+|----------|-------|------|
+| `system_to_mermaid(system)` | `SystemIR` | Structural |
+| `canonical_to_mermaid(canonical)` | `CanonicalGDS` | Canonical |
+| `spec_to_mermaid(spec)` | `GDSSpec` | By role |
+| `spec_to_mermaid(spec, group_by=...)` | `GDSSpec` | By domain |
+| `params_to_mermaid(spec)` | `GDSSpec` | Parameters |
+| `trace_to_mermaid(spec, ent, var)` | `GDSSpec` | Traceability |
+
+All accept an optional `theme=` parameter: `"neutral"`, `"default"`, `"dark"`, `"forest"`, `"base"`.
+
+### Usage Pattern
+
+```python
+from gds_viz import system_to_mermaid
+from my_model import build_system
+
+system = build_system()
+mermaid_str = system_to_mermaid(system, theme="dark")
+# Paste into GitHub markdown, mermaid.live, or mo.mermaid()
+```
+
+## Running Interactively
+
+The guide includes a [marimo notebook](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/visualization/notebook.py) with interactive dropdowns for selecting views, themes, and models:
+
+```bash
+uv run marimo run packages/gds-examples/guides/visualization/notebook.py
+```
+
+Run the test suite:
+
+```bash
+uv run --package gds-examples pytest packages/gds-examples/guides/visualization/ -v
+```
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| [`all_views_demo.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/visualization/all_views_demo.py) | All 6 view types on the SIR model |
+| [`theme_customization.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/visualization/theme_customization.py) | 5 built-in theme demos |
+| [`cross_dsl_views.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/visualization/cross_dsl_views.py) | Cross-DSL visualization comparison |
+| [`notebook.py`](https://github.com/BlockScience/gds-core/blob/main/packages/gds-examples/guides/visualization/notebook.py) | Interactive marimo notebook |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,17 @@ from gds import (
 )
 ```
 
+## Guides
+
+Interactive tutorials with code, diagrams, and runnable marimo notebooks:
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| **[Getting Started](guides/getting-started.md)** | Build a thermostat model in 5 progressive stages — from raw blocks to DSL to verification |
+| **[Rosetta Stone](guides/rosetta-stone.md)** | Same resource-pool problem modeled with stockflow, control, and game theory DSLs |
+| **[Verification](guides/verification.md)** | All 3 verification layers demonstrated with deliberately broken models |
+| **[Visualization](guides/visualization.md)** | 6 view types, 5 themes, and cross-DSL rendering with gds-viz |
+
 ## Architecture
 
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,11 @@ nav:
       - Building Models: examples/building-models.md
       - Feature Matrix: examples/feature-matrix.md
   - Guides:
-      - Layer 0 Milestone: guides/architecture-milestone-layer0.md
-      - DSL Roadmap: guides/dsl-roadmap.md
+      - Getting Started: guides/getting-started.md
+      - Rosetta Stone: guides/rosetta-stone.md
+      - Verification: guides/verification.md
+      - Visualization: guides/visualization.md
+      - Design Notes:
+          - Layer 0 Milestone: guides/architecture-milestone-layer0.md
+          - DSL Roadmap: guides/dsl-roadmap.md
   - Ecosystem: framework/ecosystem.md


### PR DESCRIPTION
## Summary

Integrates the 4 guides from `packages/gds-examples/guides/` into the mkdocs documentation site as proper pages (closes #45):

- **Getting Started** — progressive 5-stage "Build Your First Model" tutorial
- **Rosetta Stone** — same model across raw GDS, stockflow DSL, and control DSL
- **Verification** — all 3 verification layers with broken model examples
- **Visualization** — gds-viz features, themes, and cross-DSL views

Added "Guides" section to mkdocs nav and docs landing page. All Mermaid diagrams generated from actual guide code.

## Test plan

- [x] `uv run mkdocs build --strict` passes cleanly
- [x] All guide pages render with embedded Mermaid diagrams

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)