### PR TITLE
fix(gds-examples): marimo table rendering and notebook titles

### DIFF
--- a/packages/gds-examples/guides/getting_started/notebook.py
+++ b/packages/gds-examples/guides/getting_started/notebook.py
@@ -7,7 +7,7 @@ thermostat control system. Run with: marimo run notebook.py
 import marimo
 
 __generated_with = "0.13.0"
-app = marimo.App(width="medium")
+app = marimo.App(width="medium", app_title="GDS Getting Started Guide")
 
 
 @app.cell

--- a/packages/gds-examples/guides/rosetta/notebook.py
+++ b/packages/gds-examples/guides/rosetta/notebook.py
@@ -10,7 +10,7 @@ Run with: marimo run guides/rosetta/notebook.py
 import marimo
 
 __generated_with = "0.10.0"
-app = marimo.App(width="medium")
+app = marimo.App(width="medium", app_title="GDS Rosetta Stone Guide")
 
 
 @app.cell


### PR DESCRIPTION
## Summary

- Fix 6 broken markdown tables + 1 inline section in the getting_started marimo notebook that rendered as raw text due to indented f-string interpolation breaking `textwrap.dedent`
- Add `app_title` to getting_started and rosetta notebooks so they show descriptive names in the marimo browser tab instead of generic "notebook"

## Details

The getting_started notebook used indented triple-quoted f-strings with dynamically generated table rows. The rows had no leading whitespace while the template had 8 spaces, causing `textwrap.dedent` to fail. Switched to string concatenation, matching the pattern already used in the verification notebook.

Fixes #49

## Test plan

- [x] `ruff check` passes
- [x] All 56 getting_started tests pass
- [ ] Visually confirm tables render correctly: `uv run marimo run packages/gds-examples/guides/getting_started/notebook.py`
- [ ] Confirm browser tab titles for all 4 guide notebooks