### PR TITLE
fix(gds-control, gds-stockflow): set params_used on DSL-compiled blocks

### DIFF
--- a/packages/gds-control/gds_control/dsl/compile.py
+++ b/packages/gds-control/gds_control/dsl/compile.py
@@ -118,6 +118,7 @@ def _build_input_block(inp: Input) -> BoundaryAction:
         interface=Interface(
             forward_out=(port(_reference_port_name(inp.name)),),
         ),
+        params_used=[inp.name],
     )
 
 
@@ -139,12 +140,14 @@ def _build_sensor_block(sensor: Sensor) -> Policy:
 def _build_controller_block(ctrl: Controller, model: ControlModel) -> Policy:
     """Controller → Policy: receives Measurement/Reference ports, emits Control."""
     forward_in_ports = []
+    params = []
     for read_name in ctrl.reads:
         if read_name in model.sensor_names:
             forward_in_ports.append(port(_measurement_port_name(read_name)))
         else:
             # Must be an input name
             forward_in_ports.append(port(_reference_port_name(read_name)))
+            params.append(read_name)
 
     return Policy(
         name=ctrl.name,
@@ -152,6 +155,7 @@ def _build_controller_block(ctrl: Controller, model: ControlModel) -> Policy:
             forward_in=tuple(forward_in_ports),
             forward_out=(port(_control_port_name(ctrl.name)),),
         ),
+        params_used=params if params else [],
     )
 
 

--- a/packages/gds-examples/guides/visualization/test_visualization_guide.py
+++ b/packages/gds-examples/guides/visualization/test_visualization_guide.py
@@ -204,14 +204,14 @@ class TestCrossDslViews:
         di_keys = set(all_views["double_integrator"].keys())
         assert sir_keys == di_keys
 
-    def test_sir_has_parameters_double_integrator_does_not(self):
+    def test_sir_and_double_integrator_both_have_parameters(self):
         all_views = generate_cross_dsl_views()
         sir_params = all_views["sir_epidemic"]["parameter_influence"]
         di_params = all_views["double_integrator"]["parameter_influence"]
         # SIR has beta, gamma, contact_rate
         assert "param_beta" in sir_params
-        # Double integrator has no explicit parameters
-        assert "No parameters defined" in di_params
+        # Double integrator has force (Input → parameter)
+        assert "param_force" in di_params
 
     def test_both_canonical_views_have_x_nodes(self):
         all_views = generate_cross_dsl_views()

--- a/packages/gds-stockflow/stockflow/dsl/compile.py
+++ b/packages/gds-stockflow/stockflow/dsl/compile.py
@@ -118,6 +118,7 @@ def _build_converter_block(conv: Converter) -> BoundaryAction:
         interface=Interface(
             forward_out=(port(_signal_port_name(conv.name)),),
         ),
+        params_used=[conv.name],
     )
 
 


### PR DESCRIPTION
## Summary

- Fix control and stockflow DSL compilers to set `params_used` on blocks that reference registered parameters
- Control: `BoundaryAction` for inputs + `Policy` for controllers that read inputs
- Stockflow: `BoundaryAction` for converters
- Update test that incorrectly assumed double_integrator had no parameters

## Before/After

```
# Before: SpecQuery.param_to_blocks()
{'heater': []}

# After
{'heater': ['heater', 'thermo']}
```

Fixes #51

## Test plan

- [x] gds-control: 117 passed
- [x] gds-stockflow: 215 passed
- [x] gds-examples: 694 passed