### PR TITLE
fix(docs): resolve 404 pages on documentation site

### DIFF
--- a/docs/framework/api/index.md
+++ b/docs/framework/api/index.md
@@ -1,0 +1,41 @@
+# API Reference
+
+Complete API documentation for `gds-framework`, auto-generated from source docstrings.
+
+## Core
+
+| Module | Description |
+|---|---|
+| [gds](init.md) | Package root — version, top-level imports |
+| [gds.spec](spec.md) | `GDSSpec` central registry |
+| [gds.canonical](canonical.md) | Canonical `h = f . g` decomposition |
+
+## Blocks & Composition
+
+| Module | Description |
+|---|---|
+| [gds.blocks](blocks.md) | `AtomicBlock`, roles, composition operators |
+| [gds.compiler](compiler.md) | 3-stage compiler: flatten, wire, hierarchy |
+| [gds.ir](ir.md) | `SystemIR`, `BlockIR`, `WiringIR`, `HierarchyNodeIR` |
+
+## Type System
+
+| Module | Description |
+|---|---|
+| [gds.types](types.md) | `TypeDef`, token utilities, port helpers |
+| [gds.spaces](spaces.md) | `Space`, `EMPTY`, `TERMINAL` |
+| [gds.state](state.md) | `Entity`, `StateVariable` |
+
+## Verification & Query
+
+| Module | Description |
+|---|---|
+| [gds.verification](verification.md) | Generic checks (G-001..G-006), semantic checks (SC-001..SC-007) |
+| [gds.query](query.md) | Structural queries on specs and IR |
+| [gds.parameters](parameters.md) | `ParameterDef` — structural metadata |
+
+## Utilities
+
+| Module | Description |
+|---|---|
+| [gds.serialize](serialize.md) | Serialization support |

--- a/docs/framework/guide/composition.md
+++ b/docs/framework/guide/composition.md
@@ -1,0 +1,120 @@
+# Composition
+
+The composition algebra is the core of Layer 0. Four operators build complex systems from simple blocks.
+
+## Operators
+
+### Sequential Composition (`>>`)
+
+Chains blocks so the output of one feeds the input of the next. Auto-wiring matches ports by token overlap.
+
+```python
+from gds import BoundaryAction, Policy, Mechanism, interface
+
+sensor = BoundaryAction(
+    name="Sensor",
+    interface=interface(forward_out=["Temperature"]),
+)
+controller = Policy(
+    name="Controller",
+    interface=interface(
+        forward_in=["Temperature"],
+        forward_out=["Heater Command"],
+    ),
+)
+actuator = Mechanism(
+    name="Actuator",
+    interface=interface(forward_in=["Command"]),
+)
+
+pipeline = sensor >> controller >> actuator
+```
+
+Token overlap: `"Heater Command"` auto-wires to `"Command"` because they share the token `"command"`.
+
+### Parallel Composition (`|`)
+
+Runs blocks side-by-side with no interaction. No type validation between them.
+
+```python
+from gds import BoundaryAction, interface
+
+temp_sensor = BoundaryAction(
+    name="Temperature Sensor",
+    interface=interface(forward_out=["Temperature"]),
+)
+pressure_sensor = BoundaryAction(
+    name="Pressure Sensor",
+    interface=interface(forward_out=["Pressure"]),
+)
+
+sensors = temp_sensor | pressure_sensor
+```
+
+### Feedback Loop (`.feedback()`)
+
+Creates a backward signal path within a single timestep. The backward channel is **contravariant** — it flows in the opposite direction to the forward path.
+
+```python
+plant = sensor >> controller >> actuator
+system = plant.feedback(
+    backward_from=actuator,
+    backward_to=sensor,
+)
+```
+
+### Temporal Loop (`.loop()`)
+
+Feeds state from the current timestep to the next. **Covariant only** — the loop signal flows forward in time.
+
+```python
+system_with_memory = system.loop(
+    loop_from=actuator,
+    loop_to=sensor,
+)
+```
+
+## Composition Tree
+
+Domain DSLs build systems using a convergent tiered pattern:
+
+```
+(exogenous inputs | observers) >> (decision logic) >> (state dynamics)
+    .loop(state dynamics -> observers)
+```
+
+## Explicit Wiring
+
+When token overlap doesn't hold, use `StackComposition` with explicit wiring:
+
+```python
+from gds import StackComposition, Wiring
+
+pipeline = StackComposition(
+    children=[block_a, block_b],
+    wiring=[
+        Wiring(source="block_a.output_x", target="block_b.input_y"),
+    ],
+)
+```
+
+## Compilation
+
+The compiler flattens the composition tree into a flat IR:
+
+```
+Block tree -> flatten() -> list[AtomicBlock]
+           -> block_compiler() -> list[BlockIR]
+           -> _walk_wirings() -> list[WiringIR]
+           -> _extract_hierarchy() -> HierarchyNodeIR
+           = SystemIR(blocks, wirings, hierarchy)
+```
+
+See [Verification](verification.md) for the structural checks (G-001..G-006) that validate the compiled result.
+
+## See Also
+
+- [Blocks & Roles](blocks.md) — the leaf nodes that get composed
+- [Type System](types.md) — token-based matching used by auto-wiring
+- [Architecture](architecture.md) — Layer 0 design overview
+- [API Reference](../api/compiler.md) — `gds.compiler` module

--- a/docs/framework/guide/spaces.md
+++ b/docs/framework/guide/spaces.md
@@ -1,0 +1,69 @@
+# Spaces
+
+Spaces define the signal domains that flow between blocks. They describe what kind of data travels through ports in a composition.
+
+## Creating Spaces
+
+A `Space` wraps a set of named dimensions, each backed by a `TypeDef`:
+
+```python
+from gds import space, typedef
+
+Temperature = typedef("Temperature", float)
+Humidity = typedef("Humidity", float, constraint=lambda x: 0.0 <= x <= 1.0)
+
+env_space = space("Environment", temperature=Temperature, humidity=Humidity)
+```
+
+## Built-in Spaces
+
+Two sentinel spaces are provided for common patterns:
+
+| Space | Purpose |
+|---|---|
+| `EMPTY` | No signals — used for unused port groups (e.g. backward ports on a `Mechanism`) |
+| `TERMINAL` | Terminal signal — marks the end of a signal chain |
+
+```python
+from gds import EMPTY, TERMINAL
+```
+
+## Spaces in Blocks
+
+Spaces connect to blocks through interfaces. Each block has four port groups, and spaces define the data flowing through them:
+
+```python
+from gds import Policy, interface, space, typedef
+
+Command = typedef("Command", float)
+Signal = typedef("Signal", float)
+
+cmd_space = space("Command Space", command=Command)
+sig_space = space("Signal Space", signal=Signal)
+
+controller = Policy(
+    name="Controller",
+    interface=interface(
+        forward_in=["Signal"],
+        forward_out=["Command"],
+    ),
+)
+```
+
+## Registering Spaces
+
+Spaces are registered with `GDSSpec` for semantic validation:
+
+```python
+from gds import GDSSpec
+
+spec = GDSSpec(name="My System")
+spec.collect(env_space, cmd_space)  # type-dispatched registration
+```
+
+## See Also
+
+- [Type System](types.md) — TypeDefs that back space dimensions
+- [State & Entities](state.md) — state variables that use TypeDefs
+- [Blocks & Roles](blocks.md) — how spaces connect to block interfaces
+- [API Reference](../api/spaces.md) — `gds.spaces` module

--- a/docs/framework/guide/state.md
+++ b/docs/framework/guide/state.md
@@ -1,0 +1,71 @@
+# State & Entities
+
+Entities and state variables define the mutable state that a GDS system evolves over time. They live in Layer 1 (the specification framework) and are validated by TypeDefs at runtime.
+
+## Entities
+
+An `Entity` groups related state variables into a named container. Each entity represents a distinct stateful component of the system.
+
+```python
+from gds import entity, state_var, typedef
+
+Count = typedef("Count", int, constraint=lambda x: x >= 0)
+Rate = typedef("Rate", float, constraint=lambda x: 0.0 <= x <= 1.0)
+
+population = entity(
+    "Population",
+    susceptible=state_var(Count, symbol="S"),
+    infected=state_var(Count, symbol="I"),
+    recovered=state_var(Count, symbol="R"),
+)
+```
+
+### State Variables
+
+Each `StateVariable` has:
+
+- **type_def** — a `TypeDef` that validates values at runtime
+- **symbol** — a short mathematical symbol (e.g. `"S"`, `"I"`, `"R"`)
+- **description** — optional human-readable description
+
+```python
+from gds import state_var, typedef
+
+Temperature = typedef("Temperature", float)
+temp = state_var(Temperature, symbol="T", description="Current temperature in Celsius")
+```
+
+## Registering Entities
+
+Entities are registered with `GDSSpec` either explicitly or via `collect()`:
+
+```python
+from gds import GDSSpec, entity, state_var, typedef
+
+spec = GDSSpec(name="SIR Model")
+
+Count = typedef("Count", int, constraint=lambda x: x >= 0)
+population = entity("Population", s=state_var(Count, symbol="S"))
+
+# Explicit registration
+spec.register_entity(population)
+
+# Or via collect()
+spec.collect(population)
+```
+
+## Role in Canonical Form
+
+Entities define the state space **X** in the canonical decomposition `h = f . g`. The dimension of X (number of state variables across all entities) determines the character of the system:
+
+| |X| | Canonical Form | Character |
+|---|---|---|
+| 0 | h = g | Stateless (pure policy) |
+| n > 0 | h = f . g | Full dynamical system |
+
+## See Also
+
+- [Type System](types.md) — TypeDefs used by state variables
+- [Spaces](spaces.md) — signal spaces that connect blocks
+- [Specification](spec.md) — registering entities with GDSSpec
+- [API Reference](../api/state.md) — `gds.state` module

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,15 @@
+# Getting Started
+
+This page has moved. The getting started tutorial is now at:
+
+**[Getting Started Guide](../guides/getting-started.md)**
+
+The guide walks you through building a thermostat model in 5 progressive stages, from raw blocks to DSL to verification.
+
+## Other Resources
+
+| Guide | Description |
+|---|---|
+| [Rosetta Stone](../guides/rosetta-stone.md) | Same problem modeled with stockflow, control, and game theory DSLs |
+| [Verification](../guides/verification.md) | All 3 verification layers demonstrated with deliberately broken models |
+| [Visualization](../guides/visualization.md) | 6 view types, 5 themes, and cross-DSL rendering with gds-viz |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,10 @@ nav:
       - User Guide:
           - Architecture: framework/guide/architecture.md
           - Type System: framework/guide/types.md
+          - Spaces: framework/guide/spaces.md
+          - State & Entities: framework/guide/state.md
           - Blocks & Roles: framework/guide/blocks.md
+          - Composition: framework/guide/composition.md
           - Specification: framework/guide/spec.md
           - Verification: framework/guide/verification.md
           - Glossary: framework/guide/glossary.md
@@ -74,6 +77,7 @@ nav:
           - Proposals:
               - Entity Redesign: framework/design/proposals/entity-redesign.md
       - API Reference:
+          - Overview: framework/api/index.md
           - gds: framework/api/init.md
           - gds.blocks: framework/api/blocks.md
           - gds.types: framework/api/types.md
@@ -138,6 +142,8 @@ nav:
           - Crosswalk Problem: examples/examples/crosswalk.md
       - Building Models: examples/building-models.md
       - Feature Matrix: examples/feature-matrix.md
+  - Tutorials:
+      - Getting Started: tutorials/getting-started.md
   - Guides:
       - Getting Started: guides/getting-started.md
       - Rosetta Stone: guides/rosetta-stone.md


### PR DESCRIPTION
## Summary

- Adds missing guide pages for state, spaces, and composition that were returning 404
- Adds API reference index page at `/framework/api/`
- Adds redirect page at `/tutorials/getting-started/` pointing to canonical location
- Updates `mkdocs.yml` nav to include all new pages

Closes #53

## Test plan

- [ ] `uv run mkdocs build --strict` passes with no errors
- [ ] All previously-404 URLs now resolve
- [ ] Nav links work end-to-end on local `mkdocs serve`