### PR TITLE
docs(gds-viz): add usage guide with rendered diagram gallery

### DIFF
--- a/docs/viz/getting-started.md
+++ b/docs/viz/getting-started.md
@@ -12,18 +12,46 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv add gds-viz
 ```
 
+gds-viz imports as `gds_viz`:
+
+```python
+from gds_viz import system_to_mermaid, canonical_to_mermaid, spec_to_mermaid
+```
+
 ## Requirements
 
 - Python 3.12 or later
-- [gds-framework](https://pypi.org/project/gds-framework/) >= 0.2.0 (installed automatically)
+- [gds-framework](https://pypi.org/project/gds-framework/) >= 0.2.3 (installed automatically)
 
-## Basic Usage
+## How It Works
 
-gds-viz takes GDS objects (`SystemIR`, `GDSSpec`, `CanonicalGDS`) and returns Mermaid markdown strings.
+gds-viz takes GDS objects (`SystemIR`, `GDSSpec`, `CanonicalGDS`) and returns **Mermaid markdown strings**. It does not render images directly -- you paste the output into any Mermaid-compatible renderer.
 
 ```python
-from gds import compile_system, GDSSpec
+from gds_viz import system_to_mermaid
+
+mermaid_str = system_to_mermaid(system)
+print(mermaid_str)  # paste into GitHub markdown, mermaid.live, etc.
+```
+
+## Quick Start: SIR Epidemic Model
+
+This example uses the SIR epidemic model from `gds-examples` to demonstrate all six views. The model has three entities (Susceptible, Infected, Recovered), one boundary action, one policy, and three mechanisms.
+
+### Step 1: Build the Model
+
+```python
+from sir_epidemic.model import build_spec, build_system
 from gds.canonical import project_canonical
+
+spec = build_spec()
+system = build_system()
+canonical = project_canonical(spec)
+```
+
+### Step 2: Generate Views
+
+```python
 from gds_viz import (
     system_to_mermaid,
     canonical_to_mermaid,
@@ -32,17 +60,166 @@ from gds_viz import (
     trace_to_mermaid,
 )
 
-# Build your model
-spec = build_spec()       # your GDSSpec
-system = build_system()   # your SystemIR
-canonical = project_canonical(spec)
+# View 1: Structural -- compiled block topology
+print(system_to_mermaid(system))
 
-# Generate diagrams
-print(system_to_mermaid(system))        # View 1: Structural
-print(canonical_to_mermaid(canonical))  # View 2: Canonical GDS
-print(spec_to_mermaid(spec))            # View 3: Architecture by role
-print(params_to_mermaid(spec))          # View 5: Parameter influence
-print(trace_to_mermaid(spec, "Room", "temperature"))  # View 6: Traceability
+# View 2: Canonical -- h = f . g decomposition
+print(canonical_to_mermaid(canonical))
+
+# View 3: Architecture by role -- blocks grouped by GDS role
+print(spec_to_mermaid(spec))
+
+# View 5: Parameter influence -- Theta -> blocks -> entities
+print(params_to_mermaid(spec))
+
+# View 6: Traceability -- what affects Susceptible.count?
+print(trace_to_mermaid(spec, "Susceptible", "count"))
 ```
 
-Output is Mermaid markdown — renders in GitHub, GitLab, VS Code, Obsidian, and [mermaid.live](https://mermaid.live).
+### Step 3: Render
+
+Paste the Mermaid output into any compatible renderer:
+
+- **GitHub / GitLab** -- native Mermaid support in markdown files
+- **VS Code** -- with a Mermaid extension
+- **Obsidian** -- built-in support
+- **[mermaid.live](https://mermaid.live)** -- online editor
+- **MkDocs** -- with `pymdownx.superfences` Mermaid fence (used by this documentation)
+- **marimo** -- `mo.mermaid(mermaid_str)` for interactive notebooks
+
+## Rendered Output
+
+Here is the actual output from the SIR epidemic model, rendered inline.
+
+### View 1: Structural
+
+The compiled block graph from `SystemIR`. Shows composition topology with role-based shapes and wiring types.
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    Contact_Process([Contact Process]):::boundary
+    Infection_Policy[Infection Policy]:::generic
+    Update_Susceptible[[Update Susceptible]]:::mechanism
+    Update_Infected[[Update Infected]]:::mechanism
+    Update_Recovered[[Update Recovered]]:::mechanism
+    Contact_Process --Contact Signal--> Infection_Policy
+    Infection_Policy --Susceptible Delta--> Update_Susceptible
+    Infection_Policy --Infected Delta--> Update_Infected
+    Infection_Policy --Recovered Delta--> Update_Recovered
+```
+
+### View 2: Canonical GDS
+
+The mathematical decomposition: X_t --> U --> g --> f --> X_{t+1}. Shows the abstract dynamical system with state (X), input (U), policy (g), mechanism (f), and parameter space (Theta).
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    X_t(["X_t<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    X_next(["X_{t+1}<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    Theta{{"Θ<br/>gamma, beta, contact_rate"}}:::param
+    subgraph U ["Boundary (U)"]
+        Contact_Process[Contact Process]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        Update_Susceptible[Update Susceptible]:::mechanism
+        Update_Infected[Update Infected]:::mechanism
+        Update_Recovered[Update Recovered]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    Update_Susceptible -.-> |Susceptible.count| X_next
+    Update_Infected -.-> |Infected.count| X_next
+    Update_Recovered -.-> |Recovered.count| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+### View 3: Architecture by Role
+
+Blocks grouped by GDS role. Entity cylinders show which state variables each mechanism writes.
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    subgraph boundary ["Boundary (U)"]
+        Contact_Process([Contact Process]):::boundary
+    end
+    subgraph policy ["Policy (g)"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph mechanism ["Mechanism (f)"]
+        Update_Susceptible[[Update Susceptible]]:::mechanism
+        Update_Infected[[Update Infected]]:::mechanism
+        Update_Recovered[[Update Recovered]]:::mechanism
+    end
+    entity_Susceptible[("Susceptible<br/>count: S")]:::entity
+    entity_Infected[("Infected<br/>count: I")]:::entity
+    entity_Recovered[("Recovered<br/>count: R")]:::entity
+    Update_Susceptible -.-> entity_Susceptible
+    Update_Infected -.-> entity_Infected
+    Update_Recovered -.-> entity_Recovered
+    Contact_Process --ContactSignalSpace--> Infection_Policy
+    Infection_Policy --DeltaSpace--> Update_Infected
+    Infection_Policy --DeltaSpace--> Update_Recovered
+    Infection_Policy --DeltaSpace--> Update_Susceptible
+    style boundary fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style policy fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style mechanism fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+## Where Visualization Fits
+
+Visualization is a **post-compilation** concern. It operates on the same compiled artifacts that verification uses:
+
+```
+Define model → build_spec() / build_system()
+                        ↓
+              Compile → GDSSpec, SystemIR, CanonicalGDS
+                        ↓
+              ┌─────────┴──────────┐
+              ↓                    ↓
+        Verify (gds)        Visualize (gds-viz)
+```
+
+The six views are different projections of the same specification -- they never modify it, only read it. You can generate views at any point after compilation.
+
+## Next Steps
+
+- **[Views Guide](guide/views.md)** -- detailed gallery of all six view types with rendered output
+- **[Theming Guide](guide/theming.md)** -- customizing diagram appearance with 5 built-in themes
+- **[API Reference](api/init.md)** -- full function signatures and options
+- **[Visualization Guide](../guides/visualization.md)** -- cross-DSL examples and interactive notebooks

--- a/docs/viz/guide/theming.md
+++ b/docs/viz/guide/theming.md
@@ -1,19 +1,123 @@
 # Theming
 
-## Mermaid Theme
+All gds-viz functions accept an optional `theme` parameter to control diagram appearance. The `MermaidTheme` type restricts values to Mermaid's five built-in themes.
 
-All diagrams use the `neutral` Mermaid theme via the init directive:
+## Usage
 
+```python
+from gds_viz import system_to_mermaid, MermaidTheme
+
+# Pass any theme name
+mermaid = system_to_mermaid(system, theme="dark")
+
+# Type-safe with MermaidTheme literal
+theme: MermaidTheme = "forest"
+mermaid = system_to_mermaid(system, theme=theme)
 ```
+
+All view functions support theming:
+
+```python
+from gds_viz import (
+    system_to_mermaid,
+    canonical_to_mermaid,
+    spec_to_mermaid,
+    params_to_mermaid,
+    trace_to_mermaid,
+)
+
+system_to_mermaid(system, theme="neutral")
+canonical_to_mermaid(canonical, theme="dark")
+spec_to_mermaid(spec, theme="forest")
+params_to_mermaid(spec, theme="base")
+trace_to_mermaid(spec, "Entity", "var", theme="default")
+```
+
+## Available Themes
+
+| Theme | Best For | Canvas |
+|-------|----------|--------|
+| `neutral` | Light backgrounds (GitHub, docs) | Muted gray -- **default** |
+| `default` | Mermaid's built-in Material style | Blue-toned |
+| `dark` | Dark-mode renderers | Dark canvas, light text |
+| `forest` | Nature-inspired presentations | Green-tinted |
+| `base` | Minimal chrome, very light fills | Near-white |
+
+## Theme Comparison
+
+The same SIR epidemic structural diagram rendered with different themes.
+
+### Neutral (default)
+
+```mermaid
 %%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    Contact_Process([Contact Process]):::boundary
+    Infection_Policy[Infection Policy]:::generic
+    Update_Susceptible[[Update Susceptible]]:::mechanism
+    Update_Infected[[Update Infected]]:::mechanism
+    Update_Recovered[[Update Recovered]]:::mechanism
+    Contact_Process --Contact Signal--> Infection_Policy
+    Infection_Policy --Susceptible Delta--> Update_Susceptible
+    Infection_Policy --Infected Delta--> Update_Infected
+    Infection_Policy --Recovered Delta--> Update_Recovered
+```
+
+### Dark
+
+```mermaid
+%%{init:{"theme":"dark"}}%%
+flowchart TD
+    classDef boundary fill:#1e40af,stroke:#60a5fa,stroke-width:2px,color:#dbeafe
+    classDef policy fill:#92400e,stroke:#fbbf24,stroke-width:2px,color:#fef3c7
+    classDef mechanism fill:#166534,stroke:#4ade80,stroke-width:2px,color:#dcfce7
+    classDef control fill:#581c87,stroke:#c084fc,stroke-width:2px,color:#f3e8ff
+    classDef generic fill:#334155,stroke:#94a3b8,stroke-width:1px,color:#e2e8f0
+    Contact_Process([Contact Process]):::boundary
+    Infection_Policy[Infection Policy]:::generic
+    Update_Susceptible[[Update Susceptible]]:::mechanism
+    Update_Infected[[Update Infected]]:::mechanism
+    Update_Recovered[[Update Recovered]]:::mechanism
+    Contact_Process --Contact Signal--> Infection_Policy
+    Infection_Policy --Susceptible Delta--> Update_Susceptible
+    Infection_Policy --Infected Delta--> Update_Infected
+    Infection_Policy --Recovered Delta--> Update_Recovered
+```
+
+### Forest
+
+```mermaid
+%%{init:{"theme":"forest"}}%%
+flowchart TD
+    classDef boundary fill:#a7f3d0,stroke:#059669,stroke-width:2px,color:#064e3b
+    classDef policy fill:#fde68a,stroke:#b45309,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#15803d,stroke-width:2px,color:#14532d
+    classDef control fill:#d9f99d,stroke:#65a30d,stroke-width:2px,color:#365314
+    classDef generic fill:#d1d5db,stroke:#6b7280,stroke-width:1px,color:#1f2937
+    Contact_Process([Contact Process]):::boundary
+    Infection_Policy[Infection Policy]:::generic
+    Update_Susceptible[[Update Susceptible]]:::mechanism
+    Update_Infected[[Update Infected]]:::mechanism
+    Update_Recovered[[Update Recovered]]:::mechanism
+    Contact_Process --Contact Signal--> Infection_Policy
+    Infection_Policy --Susceptible Delta--> Update_Susceptible
+    Infection_Policy --Infected Delta--> Update_Infected
+    Infection_Policy --Recovered Delta--> Update_Recovered
 ```
 
 ## Color Scheme
 
-gds-viz uses a consistent color scheme across all views:
+gds-viz uses a consistent color scheme across all views. Each role and element type has a dedicated palette that adapts to the selected theme.
 
-| Role | Fill | Stroke | CSS Class |
-|---|---|---|---|
+### Neutral Theme Palette
+
+| Element | Fill | Stroke | CSS Class |
+|---------|------|--------|-----------|
 | BoundaryAction | `#93c5fd` (light blue) | `#2563eb` | `boundary` |
 | Policy | `#fcd34d` (yellow) | `#d97706` | `policy` |
 | Mechanism | `#86efac` (green) | `#16a34a` | `mechanism` |
@@ -21,14 +125,16 @@ gds-viz uses a consistent color scheme across all views:
 | Generic | `#cbd5e1` (gray) | `#64748b` | `generic` |
 | Entity | `#e2e8f0` (light gray) | `#475569` | `entity` |
 | Parameter | `#fdba74` (orange) | `#ea580c` | `param` |
-| State | `#5eead4` (teal) | `#0d9488` | `state` |
+| State (X_t) | `#5eead4` (teal) | `#0d9488` | `state` |
+| Target | `#fca5a5` (red) | `#dc2626` | `target` |
 
-## Rendering
+## Rendering Targets
 
 Output is standard Mermaid markdown. It renders in:
 
-- GitHub / GitLab (native support)
-- VS Code (with Mermaid extension)
-- Obsidian
-- [mermaid.live](https://mermaid.live) (online editor)
-- MkDocs (with pymdownx.superfences mermaid fence)
+- **GitHub / GitLab** -- native Mermaid support in markdown files and issues
+- **VS Code** -- with a Mermaid extension
+- **Obsidian** -- built-in support
+- **[mermaid.live](https://mermaid.live)** -- online editor and playground
+- **MkDocs** -- with `pymdownx.superfences` Mermaid fence (used by this documentation)
+- **marimo** -- `mo.mermaid(mermaid_str)` for interactive notebooks

--- a/docs/viz/guide/views.md
+++ b/docs/viz/guide/views.md
@@ -1,10 +1,12 @@
-# Views
+# Views Gallery
 
-gds-viz provides six complementary views of a GDS specification.
+gds-viz provides six complementary views of a GDS specification. Each view is a different projection of the same compiled artifacts, answering a different question about the system.
+
+All examples on this page use the **SIR epidemic model** from `gds-examples`.
 
 ## View 1: Structural
 
-The compiled block graph from `SystemIR`. Shows composition topology — sequential, parallel, feedback, temporal — with role-based shapes and wiring types.
+The compiled block graph from `SystemIR`. Shows composition topology -- sequential, parallel, feedback, temporal -- with role-based shapes and wiring types.
 
 ```python
 from gds_viz import system_to_mermaid
@@ -13,60 +15,362 @@ mermaid = system_to_mermaid(system)
 
 **Shape conventions:**
 
-- Stadium `([...])` — BoundaryAction
-- Double-bracket `[[...]]` — Mechanism
-- Rectangle `[...]` — Policy / other
-- Solid arrow `-->` — covariant forward flow
-- Thick arrow `==>` — contravariant feedback
-- Dashed arrow `-.->` — temporal loop
+| Shape | Meaning | Role |
+|-------|---------|------|
+| Stadium `([...])` | Exogenous input (no forward_in) | BoundaryAction |
+| Double-bracket `[[...]]` | State sink (no forward_out) | Terminal Mechanism |
+| Rectangle `[...]` | Has both inputs and outputs | Policy / other |
+
+**Arrow conventions:**
+
+| Arrow | Meaning |
+|-------|---------|
+| Solid `-->` | Covariant forward flow |
+| Thick `==>` | Contravariant feedback (within-timestep) |
+| Dashed `-.->` | Temporal loop (cross-timestep) |
+
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    Contact_Process([Contact Process]):::boundary
+    Infection_Policy[Infection Policy]:::generic
+    Update_Susceptible[[Update Susceptible]]:::mechanism
+    Update_Infected[[Update Infected]]:::mechanism
+    Update_Recovered[[Update Recovered]]:::mechanism
+    Contact_Process --Contact Signal--> Infection_Policy
+    Infection_Policy --Susceptible Delta--> Update_Susceptible
+    Infection_Policy --Infected Delta--> Update_Infected
+    Infection_Policy --Recovered Delta--> Update_Recovered
+```
+
+**Reading this diagram:** The Contact Process boundary action (stadium shape) feeds into the Infection Policy, which fans out to three terminal mechanisms (double-bracket shapes). Arrow labels show the port names used for auto-wiring.
+
+### Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `system` | `SystemIR` | required | The compiled system to visualize |
+| `show_hierarchy` | `bool` | `False` | If True, uses subgraphs for composition tree structure |
+| `theme` | `MermaidTheme` | `None` | Mermaid theme (`"neutral"`, `"dark"`, etc.) |
+
+---
 
 ## View 2: Canonical GDS
 
-The mathematical decomposition: `X_t → U → g → f → X_{t+1}` with parameter space Θ. Derives from `CanonicalGDS`.
+The mathematical decomposition: X_t --> U --> g --> f --> X_{t+1}. Derives from `CanonicalGDS` via `project_canonical()`.
 
 ```python
 from gds.canonical import project_canonical
 from gds_viz import canonical_to_mermaid
-mermaid = canonical_to_mermaid(project_canonical(spec))
+
+canonical = project_canonical(spec)
+mermaid = canonical_to_mermaid(canonical)
 ```
 
-Shows state variables in X nodes, role subgraphs (U, g, f), labeled update edges, and parameter dependencies.
+Shows:
 
-## Views 3 & 4: Architecture
+- **X_t / X_{t+1}** -- state variable nodes listing all entity variables
+- **U** -- boundary subgraph (exogenous inputs)
+- **g** -- policy subgraph (decision logic)
+- **f** -- mechanism subgraph (state dynamics)
+- **Theta** -- parameter space (hexagon) with dashed edges to g and f
+- **Update edges** -- labeled dashed arrows from mechanisms to X_{t+1}
 
-Domain-level diagrams from `GDSSpec`. Show entity state cylinders, typed wire labels, and mechanism-to-entity update edges.
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    X_t(["X_t<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    X_next(["X_{t+1}<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    Theta{{"Θ<br/>gamma, beta, contact_rate"}}:::param
+    subgraph U ["Boundary (U)"]
+        Contact_Process[Contact Process]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        Update_Susceptible[Update Susceptible]:::mechanism
+        Update_Infected[Update Infected]:::mechanism
+        Update_Recovered[Update Recovered]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    Update_Susceptible -.-> |Susceptible.count| X_next
+    Update_Infected -.-> |Infected.count| X_next
+    Update_Recovered -.-> |Recovered.count| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+**Reading this diagram:** Left-to-right flow from state X_t through boundary inputs (U), decision logic (g), and state dynamics (f) to the next state X_{t+1}. The Theta hexagon shows parameters feeding into g and f. Dashed arrows from mechanisms to X_{t+1} are labeled with the specific entity.variable they update.
+
+### Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `canonical` | `CanonicalGDS` | required | The canonical projection to visualize |
+| `show_updates` | `bool` | `True` | Label mechanism-to-X edges with entity.variable |
+| `show_parameters` | `bool` | `True` | Show Theta node when parameters exist |
+| `theme` | `MermaidTheme` | `None` | Mermaid theme |
+
+---
+
+## View 3: Architecture by Role
+
+Blocks grouped by GDS role: Boundary (U), Policy (g), Mechanism (f). Entity cylinders show state variables and which mechanisms write to them.
 
 ```python
 from gds_viz import spec_to_mermaid
-
-by_role = spec_to_mermaid(spec)                      # View 3: group by role
-by_agent = spec_to_mermaid(spec, group_by="domain")  # View 4: group by tag
+mermaid = spec_to_mermaid(spec)
 ```
 
-View 3 groups blocks by GDS role (Boundary, Policy, Mechanism, ControlAction). View 4 groups by any tag key — set tags on blocks at definition time:
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    subgraph boundary ["Boundary (U)"]
+        Contact_Process([Contact Process]):::boundary
+    end
+    subgraph policy ["Policy (g)"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph mechanism ["Mechanism (f)"]
+        Update_Susceptible[[Update Susceptible]]:::mechanism
+        Update_Infected[[Update Infected]]:::mechanism
+        Update_Recovered[[Update Recovered]]:::mechanism
+    end
+    entity_Susceptible[("Susceptible<br/>count: S")]:::entity
+    entity_Infected[("Infected<br/>count: I")]:::entity
+    entity_Recovered[("Recovered<br/>count: R")]:::entity
+    Update_Susceptible -.-> entity_Susceptible
+    Update_Infected -.-> entity_Infected
+    Update_Recovered -.-> entity_Recovered
+    Contact_Process --ContactSignalSpace--> Infection_Policy
+    Infection_Policy --DeltaSpace--> Update_Infected
+    Infection_Policy --DeltaSpace--> Update_Recovered
+    Infection_Policy --DeltaSpace--> Update_Susceptible
+    style boundary fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style policy fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style mechanism fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+**Reading this diagram:** Blocks are organized into role subgraphs. Wire labels show the Space used for communication (e.g., `ContactSignalSpace`, `DeltaSpace`). Entity cylinders at the bottom show which state variables exist and which mechanisms write to them.
+
+---
+
+## View 4: Architecture by Domain
+
+Blocks grouped by a tag key instead of GDS role. Useful for showing organizational ownership -- which team or subsystem owns each block.
 
 ```python
-sensor = BoundaryAction(name="Sensor", ..., tags={"domain": "Observation"})
+from gds_viz import spec_to_mermaid
+mermaid = spec_to_mermaid(spec, group_by="domain")
 ```
+
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart TD
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    subgraph Observation ["Observation"]
+        Contact_Process([Contact Process]):::boundary
+    end
+    subgraph Decision ["Decision"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph State_Update ["State Update"]
+        Update_Susceptible[[Update Susceptible]]:::mechanism
+        Update_Infected[[Update Infected]]:::mechanism
+        Update_Recovered[[Update Recovered]]:::mechanism
+    end
+    entity_Susceptible[("Susceptible<br/>count: S")]:::entity
+    entity_Infected[("Infected<br/>count: I")]:::entity
+    entity_Recovered[("Recovered<br/>count: R")]:::entity
+    Update_Susceptible -.-> entity_Susceptible
+    Update_Infected -.-> entity_Infected
+    Update_Recovered -.-> entity_Recovered
+    Contact_Process --ContactSignalSpace--> Infection_Policy
+    Infection_Policy --DeltaSpace--> Update_Infected
+    Infection_Policy --DeltaSpace--> Update_Recovered
+    Infection_Policy --DeltaSpace--> Update_Susceptible
+```
+
+**Reading this diagram:** Same blocks and wires as View 3, but grouped by the `"domain"` tag set on each block at definition time. The subgraph labels ("Observation", "Decision", "State Update") come from tag values, not GDS roles.
+
+!!! tip "Setting domain tags"
+    Tags are set when defining blocks:
+    ```python
+    sensor = BoundaryAction(
+        name="Contact Process",
+        ...,
+        tags={"domain": "Observation"},
+    )
+    ```
+
+---
 
 ## View 5: Parameter Influence
 
-Shows Θ → block → entity causal map. Hexagon nodes for parameters, dashed edges to blocks that use them, then forward through the dependency graph to entities.
+Shows the causal map from parameters (Theta) through blocks to entities. Answers: "if I change parameter X, which state variables are affected?"
 
 ```python
 from gds_viz import params_to_mermaid
 mermaid = params_to_mermaid(spec)
 ```
 
-Answers: "if I change parameter X, what state is affected?"
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    param_beta{{"beta"}}:::param
+    param_contact_rate{{"contact_rate"}}:::param
+    param_gamma{{"gamma"}}:::param
+    Contact_Process[Contact Process]
+    Infection_Policy[Infection Policy]
+    entity_Infected[("Infected<br/>I")]:::entity
+    entity_Recovered[("Recovered<br/>R")]:::entity
+    entity_Susceptible[("Susceptible<br/>S")]:::entity
+    param_beta -.-> Infection_Policy
+    param_contact_rate -.-> Contact_Process
+    param_gamma -.-> Infection_Policy
+    Update_Infected -.-> entity_Infected
+    Update_Susceptible -.-> entity_Susceptible
+    Update_Recovered -.-> entity_Recovered
+    Contact_Process --> Infection_Policy
+    Infection_Policy --> Update_Infected
+    Infection_Policy --> Update_Recovered
+    Infection_Policy --> Update_Susceptible
+```
+
+**Reading this diagram:** Parameter hexagons (orange) on the left feed into blocks via dashed arrows. Blocks flow through the dependency graph (solid arrows) to mechanisms, which update entity cylinders on the right. For example, `beta` feeds `Infection Policy`, which drives all three update mechanisms.
+
+---
 
 ## View 6: Traceability
 
-For a single entity variable, traces every block that can transitively affect it and every parameter feeding those blocks.
+For a single entity variable, traces every block that can transitively affect it and every parameter feeding those blocks. Right-to-left layout.
 
 ```python
 from gds_viz import trace_to_mermaid
 mermaid = trace_to_mermaid(spec, "Susceptible", "count")
 ```
 
-Right-to-left layout with thick edges for direct updates. Answers: "what controls this variable?"
+### Rendered Output
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart RL
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    target(["Susceptible.count (S)"]):::target
+    Contact_Process[Contact Process]
+    Infection_Policy[Infection Policy]
+    Update_Susceptible[Update Susceptible]
+    param_beta{{"beta"}}:::param
+    param_contact_rate{{"contact_rate"}}:::param
+    param_gamma{{"gamma"}}:::param
+    Update_Susceptible ==> target
+    Contact_Process --> Infection_Policy
+    Infection_Policy --> Update_Susceptible
+    param_contact_rate -.-> Contact_Process
+    param_beta -.-> Infection_Policy
+    param_gamma -.-> Infection_Policy
+```
+
+**Reading this diagram:** The red target node on the right is the variable being traced (`Susceptible.count`). Thick arrows (`==>`) show direct updates from mechanisms. Normal arrows show transitive dependencies. Dashed arrows show parameter influences. Reading right-to-left: `Susceptible.count` is directly updated by `Update Susceptible`, which depends on `Infection Policy`, which depends on `Contact Process` and parameters `beta`, `gamma`, and `contact_rate`.
+
+### Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `spec` | `GDSSpec` | required | The GDS specification |
+| `entity` | `str` | required | Entity name (e.g., `"Susceptible"`) |
+| `variable` | `str` | required | Variable name (e.g., `"count"`) |
+| `theme` | `MermaidTheme` | `None` | Mermaid theme |
+
+---
+
+## View Summary
+
+| # | View | Function | Input | Layout | Question |
+|:-:|------|----------|-------|--------|----------|
+| 1 | Structural | `system_to_mermaid()` | `SystemIR` | Top-down | What blocks exist and how are they wired? |
+| 2 | Canonical | `canonical_to_mermaid()` | `CanonicalGDS` | Left-right | What is the formal h = f . g decomposition? |
+| 3 | Architecture (role) | `spec_to_mermaid()` | `GDSSpec` | Top-down | How do blocks group by GDS role? |
+| 4 | Architecture (domain) | `spec_to_mermaid(group_by=...)` | `GDSSpec` | Top-down | How do blocks group by domain/agent? |
+| 5 | Parameter influence | `params_to_mermaid()` | `GDSSpec` | Left-right | What does each parameter control? |
+| 6 | Traceability | `trace_to_mermaid()` | `GDSSpec` | Right-left | What can affect a specific state variable? |
+
+## Cross-DSL Compatibility
+
+All view functions operate on `GDSSpec` and `SystemIR`, which every compilation path produces. The same functions work unchanged regardless of whether the model was built with raw GDS blocks, stockflow DSL, control DSL, or games DSL.
+
+```python
+# All of these produce the same types -- gds-viz works with all of them:
+from stockflow.dsl.compile import compile_model, compile_to_system
+from gds_control.dsl.compile import compile_model, compile_to_system
+from ogs.dsl.spec_bridge import compile_pattern_to_spec
+```

--- a/docs/viz/index.md
+++ b/docs/viz/index.md
@@ -40,6 +40,52 @@ mermaid = canonical_to_mermaid(project_canonical(spec))
 mermaid = spec_to_mermaid(spec)
 ```
 
+## Sample Output
+
+Here is a canonical GDS diagram generated from the SIR epidemic model -- `canonical_to_mermaid(project_canonical(spec))`:
+
+```mermaid
+%%{init:{"theme":"neutral"}}%%
+flowchart LR
+    classDef boundary fill:#93c5fd,stroke:#2563eb,stroke-width:2px,color:#1e3a5f
+    classDef policy fill:#fcd34d,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef mechanism fill:#86efac,stroke:#16a34a,stroke-width:2px,color:#14532d
+    classDef control fill:#d8b4fe,stroke:#9333ea,stroke-width:2px,color:#3b0764
+    classDef generic fill:#cbd5e1,stroke:#64748b,stroke-width:1px,color:#1e293b
+    classDef entity fill:#e2e8f0,stroke:#475569,stroke-width:2px,color:#0f172a
+    classDef param fill:#fdba74,stroke:#ea580c,stroke-width:2px,color:#7c2d12
+    classDef state fill:#5eead4,stroke:#0d9488,stroke-width:2px,color:#134e4a
+    classDef target fill:#fca5a5,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef empty fill:#e2e8f0,stroke:#94a3b8,stroke-width:1px,color:#475569
+    X_t(["X_t<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    X_next(["X_{t+1}<br/>Susceptible.count, Infected.count, Recovered.count"]):::state
+    Theta{{"Θ<br/>gamma, beta, contact_rate"}}:::param
+    subgraph U ["Boundary (U)"]
+        Contact_Process[Contact Process]:::boundary
+    end
+    subgraph g ["Policy (g)"]
+        Infection_Policy[Infection Policy]:::policy
+    end
+    subgraph f ["Mechanism (f)"]
+        Update_Susceptible[Update Susceptible]:::mechanism
+        Update_Infected[Update Infected]:::mechanism
+        Update_Recovered[Update Recovered]:::mechanism
+    end
+    X_t --> U
+    U --> g
+    g --> f
+    Update_Susceptible -.-> |Susceptible.count| X_next
+    Update_Infected -.-> |Infected.count| X_next
+    Update_Recovered -.-> |Recovered.count| X_next
+    Theta -.-> g
+    Theta -.-> f
+    style U fill:#dbeafe,stroke:#60a5fa,stroke-width:1px,color:#1e40af
+    style g fill:#fef3c7,stroke:#fbbf24,stroke-width:1px,color:#92400e
+    style f fill:#dcfce7,stroke:#4ade80,stroke-width:1px,color:#166534
+```
+
+See all six views in the [Views Gallery](guide/views.md).
+
 ## What gds-viz Does NOT Cover
 
 The six views exhaust what is **derivable from the GDS specification** `{h, X}`. Two views are deliberately excluded:


### PR DESCRIPTION
## Summary

- Expands gds-viz docs from stubs into full usage guide
- Adds installation instructions, import examples, and step-by-step quick start
- Renders all 6 views as live Mermaid diagrams using actual SIR model output
- Adds theme comparison gallery (neutral, dark, forest)
- Documents rendering targets (GitHub, VS Code, Obsidian, mermaid.live, MkDocs, marimo)

Closes #59

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] Mermaid diagrams render correctly on local `mkdocs serve`
- [ ] All views and themes are represented