### PR TITLE
docs: add clear installation instructions with package name mapping

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -5,7 +5,17 @@ A progressive 5-stage tutorial that teaches GDS fundamentals using a **thermosta
 ## Prerequisites
 
 - Python 3.12+
-- `gds-framework`, `gds-viz`, and `gds-control` installed (`uv sync --all-packages` from the repo root)
+- Install the required packages:
+
+```bash
+pip install gds-framework gds-viz gds-control
+```
+
+Or, if working from the monorepo:
+
+```bash
+uv sync --all-packages
+```
 
 ## Learning Path
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,20 +2,43 @@
 
 **Typed compositional specifications for complex systems**, grounded in [Generalized Dynamical Systems](https://doi.org/10.57938/e8d456ea-d975-4111-ac41-052ce73cb0cc) theory (Zargham & Shorish, 2022).
 
-## Packages
+## Installation
 
-| Package | PyPI | Description |
-|---------|------|-------------|
-| **[gds-framework](framework/index.md)** | `pip install gds-framework` | Core engine — blocks, composition algebra, compiler, verification |
-| **[gds-viz](viz/index.md)** | `pip install gds-viz` | Mermaid diagram renderers for GDS specifications |
-| **[gds-games](games/index.md)** | `pip install gds-games` | Typed DSL for compositional game theory (Open Games) |
-| **[gds-examples](examples/index.md)** | `pip install gds-examples` | Six tutorial models demonstrating every framework feature |
-
-## Quick Start
+Install individual packages from PyPI as needed:
 
 ```bash
-pip install gds-framework
+pip install gds-framework    # Core library
+pip install gds-viz          # Visualization
+pip install gds-stockflow    # Stock-flow DSL
+pip install gds-control      # Control systems DSL
+pip install gds-games        # Game theory DSL
+pip install gds-examples     # Tutorial models
 ```
+
+!!! note "PyPI names differ from import names"
+    Each package's PyPI name (what you `pip install`) differs from its Python import name.
+    Use the table below as a reference.
+
+| PyPI Package | Import Name | Description |
+|---|---|---|
+| `gds-framework` | `gds` | Core engine — blocks, composition algebra, compiler, verification |
+| `gds-viz` | `gds_viz` | Mermaid diagram renderers for GDS specifications |
+| `gds-stockflow` | `stockflow` | Declarative stock-flow DSL over GDS semantics |
+| `gds-control` | `gds_control` | State-space control DSL over GDS semantics |
+| `gds-games` | `ogs` | Typed DSL for compositional game theory (Open Games) |
+| `gds-examples` | — | Tutorial models demonstrating framework features |
+
+### For developers
+
+To work on the monorepo with all packages linked locally:
+
+```bash
+git clone https://github.com/BlockScience/gds-core.git
+cd gds-core
+uv sync --all-packages
+```
+
+## Quick Start
 
 ```python
 from gds import (
@@ -24,6 +47,15 @@ from gds import (
     typedef, entity, state_var, space, interface,
 )
 ```
+
+## Packages
+
+| Package | Docs |
+|---------|------|
+| **[gds-framework](framework/index.md)** | Core engine — blocks, composition algebra, compiler, verification |
+| **[gds-viz](viz/index.md)** | Mermaid diagram renderers for GDS specifications |
+| **[gds-games](games/index.md)** | Typed DSL for compositional game theory (Open Games) |
+| **[gds-examples](examples/index.md)** | Six tutorial models demonstrating every framework feature |
 
 ## Guides
 
@@ -43,6 +75,8 @@ gds-framework  ←  core engine (no GDS dependencies)
     ↑
 gds-viz        ←  visualization (depends on gds-framework)
 gds-games      ←  game theory DSL (depends on gds-framework)
+gds-stockflow  ←  stock-flow DSL (depends on gds-framework)
+gds-control    ←  control systems DSL (depends on gds-framework)
     ↑
 gds-examples   ←  tutorials (depends on gds-framework + gds-viz)
 ```


### PR DESCRIPTION
## Summary

- Adds prominent Installation section to docs landing page with `pip install` commands for all 6 packages
- Includes PyPI name → import name → description mapping table
- Adds callout warning that PyPI names differ from import names
- Updates getting-started prerequisites with explicit install commands
- Adds "For developers" subsection with monorepo setup

Closes #60

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] Package names and import names are accurate