### PR TITLE
fix: align root pyproject.toml gds-framework bound to >=0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "gds-framework>=0.2.0",
+    "gds-framework>=0.2.3",
     "gds-viz>=0.1.0",
     "gds-games>=0.1.0",
     "gds-stockflow>=0.1.0",


### PR DESCRIPTION
## Summary
- Root `pyproject.toml` declared `gds-framework>=0.2.0` while all downstream packages require `>=0.2.3`
- One-line fix to align the lower bound

Closes #91