### PR TITLE
refactor: rename Shipment.source_node/target_node to source/target

### DIFF
--- a/docs/business/getting-started.md
+++ b/docs/business/getting-started.md
@@ -68,11 +68,11 @@ model = SupplyChainModel(
         SupplyNode(name="Retailer", initial_inventory=100),
     ],
     shipments=[
-        Shipment(name="F->D", source_node="Factory", target_node="Distributor"),
-        Shipment(name="D->R", source_node="Distributor", target_node="Retailer"),
+        Shipment(name="F->D", source="Factory", target="Distributor"),
+        Shipment(name="D->R", source="Distributor", target="Retailer"),
     ],
     demand_sources=[
-        DemandSource(name="Customer", target_node="Retailer"),
+        DemandSource(name="Customer", target="Retailer"),
     ],
     order_policies=[
         OrderPolicy(name="Retailer Policy", node="Retailer", inputs=["Retailer"]),

--- a/docs/business/guide/diagram-types.md
+++ b/docs/business/guide/diagram-types.md
@@ -103,10 +103,10 @@ model = SupplyChainModel(
         SupplyNode(name="Retail", initial_inventory=50),
     ],
     shipments=[
-        Shipment(name="W->R", source_node="Warehouse", target_node="Retail", lead_time=2.0),
+        Shipment(name="W->R", source="Warehouse", target="Retail", lead_time=2.0),
     ],
     demand_sources=[
-        DemandSource(name="Customer Demand", target_node="Retail"),
+        DemandSource(name="Customer Demand", target="Retail"),
     ],
     order_policies=[
         OrderPolicy(name="Retail Reorder", node="Retail", inputs=["Retail"]),

--- a/docs/business/guide/verification.md
+++ b/docs/business/guide/verification.md
@@ -63,8 +63,8 @@ Self-loops (a variable causing itself) are structurally invalid:
 | ID | Name | Severity | What it checks |
 |----|------|----------|----------------|
 | SCN-001 | Network connectivity | WARNING | All nodes reachable via BFS from demand/supply paths |
-| SCN-002 | Shipment node validity | ERROR | source_node and target_node exist |
-| SCN-003 | Demand target validity | ERROR | target_node exists |
+| SCN-002 | Shipment node validity | ERROR | source and target exist |
+| SCN-003 | Demand target validity | ERROR | target exists |
 | SCN-004 | No orphan nodes | WARNING | Every node in at least one shipment or demand |
 
 ### SCN-001: Network Connectivity

--- a/docs/business/index.md
+++ b/docs/business/index.md
@@ -78,10 +78,10 @@ scn = SupplyChainModel(
         SupplyNode(name="Retailer", initial_inventory=100),
     ],
     shipments=[
-        Shipment(name="F->R", source_node="Factory", target_node="Retailer"),
+        Shipment(name="F->R", source="Factory", target="Retailer"),
     ],
     demand_sources=[
-        DemandSource(name="Customer", target_node="Retailer"),
+        DemandSource(name="Customer", target="Retailer"),
     ],
     order_policies=[
         OrderPolicy(name="Reorder", node="Retailer", inputs=["Retailer"]),

--- a/packages/gds-business/gds_business/supplychain/checks.py
+++ b/packages/gds-business/gds_business/supplychain/checks.py
@@ -21,21 +21,21 @@ def check_scn001_network_connectivity(model: SupplyChainModel) -> list[Finding]:
     # Build undirected adjacency from shipments
     adj: dict[str, set[str]] = {n.name: set() for n in model.nodes}
     for s in model.shipments:
-        if s.source_node in adj and s.target_node in adj:
-            adj[s.source_node].add(s.target_node)
-            adj[s.target_node].add(s.source_node)
+        if s.source in adj and s.target in adj:
+            adj[s.source].add(s.target)
+            adj[s.target].add(s.source)
 
     # Also connect demand source targets
     for d in model.demand_sources:
-        if d.target_node in adj:
-            adj[d.target_node].add(f"__demand_{d.name}")
+        if d.target in adj:
+            adj[d.target].add(f"__demand_{d.name}")
 
     # BFS from each demand target
     reachable: set[str] = set()
     for d in model.demand_sources:
-        if d.target_node not in adj:
+        if d.target not in adj:
             continue
-        queue = [d.target_node]
+        queue = [d.target]
         visited: set[str] = set()
         while queue:
             node = queue.pop(0)
@@ -76,32 +76,32 @@ def check_scn001_network_connectivity(model: SupplyChainModel) -> list[Finding]:
 
 
 def check_scn002_shipment_node_validity(model: SupplyChainModel) -> list[Finding]:
-    """SCN-002: Shipment source_node and target_node exist."""
+    """SCN-002: Shipment source and target exist."""
     findings: list[Finding] = []
     for s in model.shipments:
-        src_valid = s.source_node in model.node_names
+        src_valid = s.source in model.node_names
         findings.append(
             Finding(
                 check_id="SCN-002",
                 severity=Severity.ERROR,
                 message=(
-                    f"Shipment {s.name!r} source_node {s.source_node!r} "
+                    f"Shipment {s.name!r} source {s.source!r} "
                     f"{'is' if src_valid else 'is NOT'} a declared node"
                 ),
-                source_elements=[s.name, s.source_node],
+                source_elements=[s.name, s.source],
                 passed=src_valid,
             )
         )
-        tgt_valid = s.target_node in model.node_names
+        tgt_valid = s.target in model.node_names
         findings.append(
             Finding(
                 check_id="SCN-002",
                 severity=Severity.ERROR,
                 message=(
-                    f"Shipment {s.name!r} target_node {s.target_node!r} "
+                    f"Shipment {s.name!r} target {s.target!r} "
                     f"{'is' if tgt_valid else 'is NOT'} a declared node"
                 ),
-                source_elements=[s.name, s.target_node],
+                source_elements=[s.name, s.target],
                 passed=tgt_valid,
             )
         )
@@ -109,19 +109,19 @@ def check_scn002_shipment_node_validity(model: SupplyChainModel) -> list[Finding
 
 
 def check_scn003_demand_target_validity(model: SupplyChainModel) -> list[Finding]:
-    """SCN-003: Demand target_node exists."""
+    """SCN-003: Demand target exists."""
     findings: list[Finding] = []
     for d in model.demand_sources:
-        valid = d.target_node in model.node_names
+        valid = d.target in model.node_names
         findings.append(
             Finding(
                 check_id="SCN-003",
                 severity=Severity.ERROR,
                 message=(
-                    f"DemandSource {d.name!r} target_node {d.target_node!r} "
+                    f"DemandSource {d.name!r} target {d.target!r} "
                     f"{'is' if valid else 'is NOT'} a declared node"
                 ),
-                source_elements=[d.name, d.target_node],
+                source_elements=[d.name, d.target],
                 passed=valid,
             )
         )
@@ -133,10 +133,10 @@ def check_scn004_no_orphan_nodes(model: SupplyChainModel) -> list[Finding]:
     findings: list[Finding] = []
     connected: set[str] = set()
     for s in model.shipments:
-        connected.add(s.source_node)
-        connected.add(s.target_node)
+        connected.add(s.source)
+        connected.add(s.target)
     for d in model.demand_sources:
-        connected.add(d.target_node)
+        connected.add(d.target)
 
     for node in model.nodes:
         is_connected = node.name in connected

--- a/packages/gds-business/gds_business/supplychain/compile.py
+++ b/packages/gds-business/gds_business/supplychain/compile.py
@@ -124,7 +124,7 @@ def _build_policy_block(policy: OrderPolicy, model: SupplyChainModel) -> Policy:
 
     # Demand signals targeting this policy's node
     for d in model.demand_sources:
-        if d.target_node == policy.node:
+        if d.target == policy.node:
             in_ports.append(port(_signal_port_name(d.name)))
 
     # Inventory signals from observed nodes
@@ -286,7 +286,7 @@ def compile_scn(model: SupplyChainModel) -> GDSSpec:
     # Demand -> Policy wires
     for d in model.demand_sources:
         for p in model.order_policies:
-            if p.node == d.target_node:
+            if p.node == d.target:
                 wires.append(
                     Wire(source=d.name, target=p.name, space="SCN DemandSpace")
                 )

--- a/packages/gds-business/gds_business/supplychain/elements.py
+++ b/packages/gds-business/gds_business/supplychain/elements.py
@@ -26,8 +26,8 @@ class Shipment(BaseModel, frozen=True):
     """
 
     name: str
-    source_node: str
-    target_node: str
+    source: str
+    target: str
     lead_time: float = 1.0
 
 
@@ -38,7 +38,7 @@ class DemandSource(BaseModel, frozen=True):
     """
 
     name: str
-    target_node: str
+    target: str
     description: str = ""
 
 

--- a/packages/gds-business/gds_business/supplychain/model.py
+++ b/packages/gds-business/gds_business/supplychain/model.py
@@ -62,22 +62,22 @@ class SupplyChainModel(BaseModel):
 
         # 3. Shipment source/target reference declared nodes
         for s in self.shipments:
-            if s.source_node not in node_names:
+            if s.source not in node_names:
                 errors.append(
-                    f"Shipment {s.name!r} source_node {s.source_node!r} "
+                    f"Shipment {s.name!r} source {s.source!r} "
                     f"is not a declared node"
                 )
-            if s.target_node not in node_names:
+            if s.target not in node_names:
                 errors.append(
-                    f"Shipment {s.name!r} target_node {s.target_node!r} "
+                    f"Shipment {s.name!r} target {s.target!r} "
                     f"is not a declared node"
                 )
 
         # 4. Demand target references a declared node
         for d in self.demand_sources:
-            if d.target_node not in node_names:
+            if d.target not in node_names:
                 errors.append(
-                    f"DemandSource {d.name!r} target_node {d.target_node!r} "
+                    f"DemandSource {d.name!r} target {d.target!r} "
                     f"is not a declared node"
                 )
 

--- a/packages/gds-business/tests/supplychain/test_checks.py
+++ b/packages/gds-business/tests/supplychain/test_checks.py
@@ -21,8 +21,8 @@ def _connected_model() -> SupplyChainModel:
     return SupplyChainModel(
         name="Connected",
         nodes=[SupplyNode(name="A"), SupplyNode(name="B")],
-        shipments=[Shipment(name="S1", source_node="A", target_node="B")],
-        demand_sources=[DemandSource(name="D1", target_node="B")],
+        shipments=[Shipment(name="S1", source="A", target="B")],
+        demand_sources=[DemandSource(name="D1", target="B")],
     )
 
 
@@ -34,8 +34,8 @@ def _disconnected_model() -> SupplyChainModel:
             SupplyNode(name="B"),
             SupplyNode(name="C"),
         ],
-        shipments=[Shipment(name="S1", source_node="A", target_node="B")],
-        demand_sources=[DemandSource(name="D1", target_node="B")],
+        shipments=[Shipment(name="S1", source="A", target="B")],
+        demand_sources=[DemandSource(name="D1", target="B")],
     )
 
 
@@ -47,7 +47,7 @@ def _orphan_model() -> SupplyChainModel:
             SupplyNode(name="B"),
             SupplyNode(name="C"),
         ],
-        shipments=[Shipment(name="S1", source_node="A", target_node="B")],
+        shipments=[Shipment(name="S1", source="A", target="B")],
     )
 
 
@@ -55,7 +55,7 @@ def _no_shipments_model() -> SupplyChainModel:
     return SupplyChainModel(
         name="NoShipments",
         nodes=[SupplyNode(name="A")],
-        demand_sources=[DemandSource(name="D1", target_node="A")],
+        demand_sources=[DemandSource(name="D1", target="A")],
     )
 
 

--- a/packages/gds-business/tests/supplychain/test_compile.py
+++ b/packages/gds-business/tests/supplychain/test_compile.py
@@ -29,12 +29,12 @@ def _beer_game() -> SupplyChainModel:
             SupplyNode(name="Retailer", initial_inventory=100),
         ],
         shipments=[
-            Shipment(name="F->D", source_node="Factory", target_node="Distributor"),
-            Shipment(name="D->W", source_node="Distributor", target_node="Wholesaler"),
-            Shipment(name="W->R", source_node="Wholesaler", target_node="Retailer"),
+            Shipment(name="F->D", source="Factory", target="Distributor"),
+            Shipment(name="D->W", source="Distributor", target="Wholesaler"),
+            Shipment(name="W->R", source="Wholesaler", target="Retailer"),
         ],
         demand_sources=[
-            DemandSource(name="Customer Demand", target_node="Retailer"),
+            DemandSource(name="Customer Demand", target="Retailer"),
         ],
         order_policies=[
             OrderPolicy(name="Retailer Policy", node="Retailer", inputs=["Retailer"]),
@@ -57,8 +57,8 @@ def _simple_model() -> SupplyChainModel:
     return SupplyChainModel(
         name="Simple SCN",
         nodes=[SupplyNode(name="W1"), SupplyNode(name="W2")],
-        shipments=[Shipment(name="S1", source_node="W1", target_node="W2")],
-        demand_sources=[DemandSource(name="D1", target_node="W2")],
+        shipments=[Shipment(name="S1", source="W1", target="W2")],
+        demand_sources=[DemandSource(name="D1", target="W2")],
         order_policies=[OrderPolicy(name="OP1", node="W2", inputs=["W1"])],
     )
 

--- a/packages/gds-business/tests/supplychain/test_elements.py
+++ b/packages/gds-business/tests/supplychain/test_elements.py
@@ -36,31 +36,31 @@ class TestSupplyNode:
 
 class TestShipment:
     def test_create(self):
-        s = Shipment(name="S1", source_node="A", target_node="B")
-        assert s.source_node == "A"
-        assert s.target_node == "B"
+        s = Shipment(name="S1", source="A", target="B")
+        assert s.source == "A"
+        assert s.target == "B"
         assert s.lead_time == 1.0
 
     def test_with_lead_time(self):
-        s = Shipment(name="S1", source_node="A", target_node="B", lead_time=3.0)
+        s = Shipment(name="S1", source="A", target="B", lead_time=3.0)
         assert s.lead_time == 3.0
 
     def test_frozen(self):
-        s = Shipment(name="S1", source_node="A", target_node="B")
+        s = Shipment(name="S1", source="A", target="B")
         with pytest.raises(ValidationError):
-            s.source_node = "C"
+            s.source = "C"
 
 
 class TestDemandSource:
     def test_create(self):
-        d = DemandSource(name="D1", target_node="Retail")
+        d = DemandSource(name="D1", target="Retail")
         assert d.name == "D1"
-        assert d.target_node == "Retail"
+        assert d.target == "Retail"
 
     def test_frozen(self):
-        d = DemandSource(name="D1", target_node="Retail")
+        d = DemandSource(name="D1", target="Retail")
         with pytest.raises(ValidationError):
-            d.target_node = "Other"
+            d.target = "Other"
 
 
 class TestOrderPolicy:

--- a/packages/gds-business/tests/supplychain/test_model.py
+++ b/packages/gds-business/tests/supplychain/test_model.py
@@ -22,8 +22,8 @@ class TestSupplyChainModelConstruction:
         m = SupplyChainModel(
             name="test",
             nodes=[SupplyNode(name="W1"), SupplyNode(name="W2")],
-            shipments=[Shipment(name="S1", source_node="W1", target_node="W2")],
-            demand_sources=[DemandSource(name="D1", target_node="W2")],
+            shipments=[Shipment(name="S1", source="W1", target="W2")],
+            demand_sources=[DemandSource(name="D1", target="W2")],
             order_policies=[OrderPolicy(name="OP1", node="W2", inputs=["W1"])],
         )
         assert len(m.shipments) == 1
@@ -42,27 +42,27 @@ class TestSupplyChainModelConstruction:
             )
 
     def test_shipment_source_invalid_fails(self):
-        with pytest.raises(BizValidationError, match="source_node.*not a declared"):
+        with pytest.raises(BizValidationError, match="source.*not a declared"):
             SupplyChainModel(
                 name="test",
                 nodes=[SupplyNode(name="W1")],
-                shipments=[Shipment(name="S1", source_node="Z", target_node="W1")],
+                shipments=[Shipment(name="S1", source="Z", target="W1")],
             )
 
     def test_shipment_target_invalid_fails(self):
-        with pytest.raises(BizValidationError, match="target_node.*not a declared"):
+        with pytest.raises(BizValidationError, match="target.*not a declared"):
             SupplyChainModel(
                 name="test",
                 nodes=[SupplyNode(name="W1")],
-                shipments=[Shipment(name="S1", source_node="W1", target_node="Z")],
+                shipments=[Shipment(name="S1", source="W1", target="Z")],
             )
 
     def test_demand_target_invalid_fails(self):
-        with pytest.raises(BizValidationError, match="target_node.*not a declared"):
+        with pytest.raises(BizValidationError, match="target.*not a declared"):
             SupplyChainModel(
                 name="test",
                 nodes=[SupplyNode(name="W1")],
-                demand_sources=[DemandSource(name="D1", target_node="Z")],
+                demand_sources=[DemandSource(name="D1", target="Z")],
             )
 
     def test_order_policy_node_invalid_fails(self):

--- a/packages/gds-business/tests/test_cross_diagram.py
+++ b/packages/gds-business/tests/test_cross_diagram.py
@@ -51,10 +51,10 @@ def _scn() -> SupplyChainModel:
             SupplyNode(name="Retailer"),
         ],
         shipments=[
-            Shipment(name="F->R", source_node="Factory", target_node="Retailer"),
+            Shipment(name="F->R", source="Factory", target="Retailer"),
         ],
         demand_sources=[
-            DemandSource(name="Customer", target_node="Retailer"),
+            DemandSource(name="Customer", target="Retailer"),
         ],
         order_policies=[
             OrderPolicy(name="Reorder", node="Retailer", inputs=["Retailer"]),


### PR DESCRIPTION
## Summary
- Rename `Shipment.source_node` → `source` and `target_node` → `target` to match ecosystem convention
- Updated across 4 source files, 5 test files, 4 doc pages
- All 175 gds-business tests pass

Closes #97