### PR TITLE
refactor: standardize verify() parameter name to domain_checks across all DSLs

### DIFF
--- a/packages/gds-business/gds_business/supplychain/model.py
+++ b/packages/gds-business/gds_business/supplychain/model.py
@@ -64,13 +64,11 @@ class SupplyChainModel(BaseModel):
         for s in self.shipments:
             if s.source not in node_names:
                 errors.append(
-                    f"Shipment {s.name!r} source {s.source!r} "
-                    f"is not a declared node"
+                    f"Shipment {s.name!r} source {s.source!r} is not a declared node"
                 )
             if s.target not in node_names:
                 errors.append(
-                    f"Shipment {s.name!r} target {s.target!r} "
-                    f"is not a declared node"
+                    f"Shipment {s.name!r} target {s.target!r} is not a declared node"
                 )
 
         # 4. Demand target references a declared node

--- a/packages/gds-control/gds_control/verification/engine.py
+++ b/packages/gds-control/gds_control/verification/engine.py
@@ -16,7 +16,7 @@ from gds_control.verification.checks import ALL_CS_CHECKS
 
 def verify(
     model: ControlModel,
-    cs_checks: list[Callable[[ControlModel], list[Finding]]] | None = None,
+    domain_checks: list[Callable[[ControlModel], list[Finding]]] | None = None,
     include_gds_checks: bool = True,
 ) -> VerificationReport:
     """Run verification checks on a ControlModel.
@@ -26,10 +26,10 @@ def verify(
 
     Args:
         model: The control system model to verify.
-        cs_checks: Optional subset of CS checks. Defaults to all.
+        domain_checks: Optional subset of CS checks. Defaults to all.
         include_gds_checks: Whether to compile and run GDS generic checks.
     """
-    checks = cs_checks or ALL_CS_CHECKS
+    checks = domain_checks or ALL_CS_CHECKS
     findings: list[Finding] = []
 
     # Phase 1: CS checks on model

--- a/packages/gds-framework/gds/verification/generic_checks.py
+++ b/packages/gds-framework/gds/verification/generic_checks.py
@@ -78,10 +78,7 @@ def check_g002_signature_completeness(system: SystemIR) -> list[Finding]:
 
         # BoundaryAction blocks have no inputs by design — only check outputs
         is_boundary = block.block_type == "boundary"
-        if is_boundary:
-            has_required = has_output
-        else:
-            has_required = has_input and has_output
+        has_required = has_output if is_boundary else has_input and has_output
 
         missing = []
         if not has_input:

--- a/packages/gds-games/ogs/verification/engine.py
+++ b/packages/gds-games/ogs/verification/engine.py
@@ -56,14 +56,14 @@ ALL_CHECKS: list[Callable[[PatternIR], list[Finding]]] = OGS_CHECKS
 
 def verify(
     pattern: PatternIR,
-    checks: list[Callable[[PatternIR], list[Finding]]] | None = None,
+    domain_checks: list[Callable[[PatternIR], list[Finding]]] | None = None,
     include_gds_checks: bool = True,
 ) -> VerificationReport:
     """Run verification checks against a PatternIR.
 
     Args:
         pattern: The pattern to verify.
-        checks: Optional subset of OGS domain checks to run. Defaults to
+        domain_checks: Optional subset of OGS domain checks to run. Defaults to
             ``ALL_CHECKS`` (8 OGS-specific checks).
         include_gds_checks: Run GDS generic checks (G-001..G-006) via
             ``to_system_ir()`` projection. Defaults to True.
@@ -71,7 +71,7 @@ def verify(
     Returns:
         A VerificationReport with all findings.
     """
-    checks = checks or ALL_CHECKS
+    checks = domain_checks or ALL_CHECKS
     findings: list[Finding] = []
     for check_fn in checks:
         findings.extend(check_fn(pattern))

--- a/packages/gds-stockflow/stockflow/verification/engine.py
+++ b/packages/gds-stockflow/stockflow/verification/engine.py
@@ -16,7 +16,7 @@ from stockflow.verification.checks import ALL_SF_CHECKS
 
 def verify(
     model: StockFlowModel,
-    sf_checks: list[Callable[[StockFlowModel], list[Finding]]] | None = None,
+    domain_checks: list[Callable[[StockFlowModel], list[Finding]]] | None = None,
     include_gds_checks: bool = True,
 ) -> VerificationReport:
     """Run verification checks on a StockFlowModel.
@@ -26,10 +26,10 @@ def verify(
 
     Args:
         model: The stock-flow model to verify.
-        sf_checks: Optional subset of SF checks. Defaults to all.
+        domain_checks: Optional subset of SF checks. Defaults to all.
         include_gds_checks: Whether to compile and run GDS generic checks.
     """
-    checks = sf_checks or ALL_SF_CHECKS
+    checks = domain_checks or ALL_SF_CHECKS
     findings: list[Finding] = []
 
     # Phase 1: SF checks on model

--- a/packages/gds-stockflow/tests/test_verification.py
+++ b/packages/gds-stockflow/tests/test_verification.py
@@ -133,7 +133,7 @@ class TestVerifyEngine:
     def test_verify_specific_checks(self, good_model):
         report = verify(
             good_model,
-            sf_checks=[check_sf001_orphan_stocks],
+            domain_checks=[check_sf001_orphan_stocks],
             include_gds_checks=False,
         )
         assert all(f.check_id == "SF-001" for f in report.findings)


### PR DESCRIPTION
## Summary
- Rename `sf_checks` → `domain_checks` in stockflow
- Rename `cs_checks` → `domain_checks` in control
- Rename `checks` → `domain_checks` in games (OGS)
- Software and business already used `domain_checks`
- Updated all callers and tests

Closes #89