### PR TITLE
feat: gds-owl package + Paper Defs 2.5/2.7 bridge (Steps 1-2)

### DIFF
--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -7,7 +7,7 @@ A hands-on walkthrough of the three verification layers in GDS, using deliberate
 | Layer | Checks | Operates on | Catches |
 |-------|--------|-------------|---------|
 | **Generic** | G-001..G-006 | `SystemIR` | Structural topology errors |
-| **Semantic** | SC-001..SC-007 | `GDSSpec` | Domain property violations |
+| **Semantic** | SC-001..SC-009 | `GDSSpec` | Domain property violations |
 | **Domain** | SF-001..SF-005 | DSL model | DSL-specific errors |
 
 Each layer operates on a different representation, and the layers are complementary: a model can pass all generic checks but fail semantic checks (and vice versa).
@@ -357,6 +357,8 @@ gds_findings = [f for f in report.findings if f.check_id.startswith("G-")]
 | SC-005 | Parameter refs | Unregistered params |
 | SC-006 | Canonical f | No mechanisms |
 | SC-007 | Canonical X | No state space |
+| SC-008 | Admissibility refs | Invalid boundary block or state deps |
+| SC-009 | Transition reads | Invalid mechanism reads or block deps |
 
 ### Domain Checks (StockFlowModel)
 

--- a/packages/gds-control/gds_control/dsl/compile.py
+++ b/packages/gds-control/gds_control/dsl/compile.py
@@ -378,6 +378,23 @@ def compile_model(model: ControlModel) -> GDSSpec:
             )
         )
 
+    # 7. Register transition signatures (mechanism read dependencies)
+    from gds.constraints import TransitionSignature
+
+    for state in model.states:
+        driving_controllers = [
+            ctrl.name
+            for ctrl in model.controllers
+            if state.name in ctrl.drives
+        ]
+        spec.register_transition_signature(
+            TransitionSignature(
+                mechanism=_dynamics_block_name(state.name),
+                reads=[(state.name, "value")],
+                depends_on_blocks=driving_controllers,
+            )
+        )
+
     return spec
 
 

--- a/packages/gds-control/tests/test_integration.py
+++ b/packages/gds-control/tests/test_integration.py
@@ -52,6 +52,25 @@ def open_loop_model():
     )
 
 
+class TestTransitionSignatures:
+    def test_siso_signature(self, siso_model):
+        spec = compile_model(siso_model)
+        assert len(spec.transition_signatures) == 1
+        ts = spec.transition_signatures["x Dynamics"]
+        assert ("x", "value") in ts.reads
+        assert "K" in ts.depends_on_blocks
+
+    def test_mimo_signatures(self, mimo_model):
+        spec = compile_model(mimo_model)
+        assert len(spec.transition_signatures) == 2
+        ts1 = spec.transition_signatures["x1 Dynamics"]
+        assert ("x1", "value") in ts1.reads
+        assert "K1" in ts1.depends_on_blocks
+        ts2 = spec.transition_signatures["x2 Dynamics"]
+        assert ("x2", "value") in ts2.reads
+        assert "K2" in ts2.depends_on_blocks
+
+
 class TestSISOIntegration:
     def test_compile_and_canonical(self, siso_model):
         spec = compile_model(siso_model)

--- a/packages/gds-examples/control/thermostat/model.py
+++ b/packages/gds-examples/control/thermostat/model.py
@@ -29,6 +29,7 @@ Composition: (sensor >> controller >> plant >> update).feedback(
 from gds.blocks.composition import Wiring
 from gds.blocks.roles import BoundaryAction, ControlAction, Mechanism, Policy
 from gds.compiler.compile import compile_system
+from gds.constraints import AdmissibleInputConstraint
 from gds.ir.models import FlowDirection, SystemIR
 from gds.spaces import Space
 from gds.spec import GDSSpec, SpecWiring, Wire
@@ -252,6 +253,17 @@ def build_spec() -> GDSSpec:
                     space="EnergyCostSpace",
                 ),
             ],
+        )
+    )
+
+    # Admissibility constraint: sensor reading depends on room temperature.
+    # Paper Def 2.5 — U_x: the observation is state-dependent.
+    spec.register_admissibility(
+        AdmissibleInputConstraint(
+            name="sensor_state_dependency",
+            boundary_block="Temperature Sensor",
+            depends_on=[("Room", "temperature")],
+            description="Sensor reading depends on actual room temperature",
         )
     )
 

--- a/packages/gds-examples/control/thermostat/test_model.py
+++ b/packages/gds-examples/control/thermostat/test_model.py
@@ -146,6 +146,20 @@ class TestSpec:
         spec = build_spec()
         assert set(spec.parameters.keys()) == {"setpoint", "Kp", "Ki", "Kd"}
 
+    def test_admissibility_constraint_registered(self):
+        spec = build_spec()
+        assert len(spec.admissibility_constraints) == 1
+        ac = spec.admissibility_constraints["sensor_state_dependency"]
+        assert ac.boundary_block == "Temperature Sensor"
+        assert ("Room", "temperature") in ac.depends_on
+
+    def test_admissibility_sc008_passes(self):
+        from gds.verification.spec_checks import check_admissibility_references
+
+        spec = build_spec()
+        findings = check_admissibility_references(spec)
+        assert all(f.passed for f in findings)
+
 
 class TestVerification:
     def test_generic_checks_pass(self):

--- a/packages/gds-examples/games/insurance/model.py
+++ b/packages/gds-examples/games/insurance/model.py
@@ -27,6 +27,7 @@ Composition: claim >> risk >> premium >> payout >> reserve_update
 
 from gds.blocks.roles import BoundaryAction, ControlAction, Mechanism, Policy
 from gds.compiler.compile import compile_system
+from gds.constraints import AdmissibleInputConstraint
 from gds.ir.models import SystemIR
 from gds.spaces import Space
 from gds.spec import GDSSpec, SpecWiring, Wire
@@ -276,6 +277,19 @@ def build_spec() -> GDSSpec:
                     space="PayoutResultSpace",
                 ),
             ],
+        )
+    )
+
+    # Admissibility constraint: claim amount bounded by insurer reserve.
+    # Paper Def 2.5 — U_x: the set of admissible inputs depends on state.
+    spec.register_admissibility(
+        AdmissibleInputConstraint(
+            name="solvency_constraint",
+            boundary_block="Claim Arrival",
+            depends_on=[("Insurer", "reserve")],
+            constraint=lambda state, u: u.get("amount", 0)
+            <= state["Insurer"]["reserve"],
+            description="Claim amount cannot exceed insurer reserve (solvency)",
         )
     )
 

--- a/packages/gds-examples/games/insurance/test_model.py
+++ b/packages/gds-examples/games/insurance/test_model.py
@@ -144,6 +144,20 @@ class TestSpec:
             "coverage_limit",
         }
 
+    def test_admissibility_constraint_registered(self):
+        spec = build_spec()
+        assert len(spec.admissibility_constraints) == 1
+        ac = spec.admissibility_constraints["solvency_constraint"]
+        assert ac.boundary_block == "Claim Arrival"
+        assert ("Insurer", "reserve") in ac.depends_on
+
+    def test_admissibility_sc008_passes(self):
+        from gds.verification.spec_checks import check_admissibility_references
+
+        spec = build_spec()
+        findings = check_admissibility_references(spec)
+        assert all(f.passed for f in findings)
+
 
 class TestVerification:
     def test_ir_compilation(self):

--- a/packages/gds-framework/CLAUDE.md
+++ b/packages/gds-framework/CLAUDE.md
@@ -70,6 +70,8 @@ from gds import (
     check_type_safety,                       # (spec) -> list[Finding]  SC-004
     check_parameter_references,              # (spec) -> list[Finding]  SC-005
     check_canonical_wellformedness,          # (spec) -> list[Finding]  SC-006/SC-007
+    check_admissibility_references,          # (spec) -> list[Finding]  SC-008
+    check_transition_reads,                  # (spec) -> list[Finding]  SC-009
 
     # Custom checks
     gds_check, get_custom_checks, all_checks,  # decorator + registries
@@ -213,7 +215,7 @@ canonical = gds.project_canonical(spec)  # derives h = f . g
 Domain-neutral engine. Blocks with bidirectional typed interfaces, composed via `>>`, `|`, `.feedback()`, `.loop()`. A 3-stage compiler flattens composition trees into flat IR. Six generic checks (G-001..G-006) validate structural properties.
 
 **Layer 1 — Specification Framework** (`spec.py`, `canonical.py`, `state.py`, `spaces.py`, `types/`):
-GDS theory layer. `GDSSpec` registry for types, spaces, entities, blocks, wirings, parameters. `project_canonical()` derives formal `h = f . g` decomposition. Seven semantic checks (SC-001..SC-007) validate domain properties.
+GDS theory layer. `GDSSpec` registry for types, spaces, entities, blocks, wirings, parameters, admissibility constraints, and transition signatures. `project_canonical()` derives formal `h = f . g` decomposition. Nine semantic checks (SC-001..SC-009) validate domain properties.
 
 Layers are loosely coupled: use the composition algebra without `GDSSpec`, or use `GDSSpec` without the compiler.
 

--- a/packages/gds-stockflow/stockflow/dsl/compile.py
+++ b/packages/gds-stockflow/stockflow/dsl/compile.py
@@ -391,6 +391,23 @@ def compile_model(model: StockFlowModel) -> GDSSpec:
             )
         )
 
+    # 7. Register transition signatures (mechanism read dependencies)
+    from gds.constraints import TransitionSignature
+
+    for stock in model.stocks:
+        connected_flows = [
+            flow.name
+            for flow in model.flows
+            if flow.target == stock.name or flow.source == stock.name
+        ]
+        spec.register_transition_signature(
+            TransitionSignature(
+                mechanism=_accumulation_block_name(stock.name),
+                reads=[(stock.name, "level")],
+                depends_on_blocks=connected_flows,
+            )
+        )
+
     return spec
 
 

--- a/packages/gds-stockflow/tests/test_integration.py
+++ b/packages/gds-stockflow/tests/test_integration.py
@@ -81,6 +81,14 @@ class TestPopulationEndToEnd:
         errors = spec.validate_spec()
         assert len(errors) == 0, f"Spec validation errors: {errors}"
 
+    def test_transition_signatures_emitted(self, model):
+        spec = compile_model(model)
+        assert len(spec.transition_signatures) == 1
+        ts = spec.transition_signatures["Population Accumulation"]
+        assert ("Population", "level") in ts.reads
+        assert "Births" in ts.depends_on_blocks
+        assert "Deaths" in ts.depends_on_blocks
+
 
 class TestPredatorPreyEndToEnd:
     """Two-stock predator-prey model."""


### PR DESCRIPTION
## Summary

- **gds-owl package**: OWL/Turtle ontology, SHACL shapes, SPARQL queries for GDS specs. Full round-trip (Pydantic → RDF → Pydantic) with 157 tests. Formal representability analysis documenting what survives the OWL boundary (structure) and what doesn't (computation).
- **AdmissibleInputConstraint (Paper Def 2.5)**: Declares state-dependent input constraints on BoundaryAction blocks. Keyed by name, allows multiple constraints per boundary. SC-008 validates references.
- **TransitionSignature (Paper Def 2.7)**: Declares mechanism read dependencies. Complements Mechanism.updates (writes). SC-009 validates references.
- **DSL compiler integration**: StockFlow and Control compilers emit TransitionSignature for each mechanism during `compile_model()`.
- **Example demonstrations**: Insurance (solvency constraint) and thermostat (sensor state dependency) demonstrate AdmissibleInputConstraint.

Both follow the f_struct / f_behav split: dependency graphs are structural (R1, exported to OWL), actual functions are behavioral (R3, lossy).

## Changes across packages

| Package | What changed |
|---------|-------------|
| gds-framework | `constraints.py`, SC-008/SC-009, CanonicalGDS fields, SpecQuery methods, serialization |
| gds-owl | Full package: ontology, export/import, SHACL, SPARQL, representability analysis |
| gds-stockflow | `compile_model()` emits TransitionSignature per stock mechanism |
| gds-control | `compile_model()` emits TransitionSignature per state mechanism |
| gds-examples | Insurance + thermostat demonstrate AdmissibleInputConstraint |
| docs | Verification guide, paper-implementation-gap, formal-representability |

## Test plan

- [x] gds-framework: 477 passed
- [x] gds-stockflow: 216 passed
- [x] gds-control: 119 passed
- [x] gds-owl: 157 passed
- [x] gds-examples: 836 passed
- [x] Lint clean across all packages