### PR TITLE
fix: resolve CodeQL URL substring sanitization alert

### DIFF
--- a/packages/gds-owl/tests/test_export.py
+++ b/packages/gds-owl/tests/test_export.py
@@ -137,7 +137,7 @@ class TestSpecToGraph:
     def test_custom_base_uri(self, thermostat_spec: GDSSpec) -> None:
         g = spec_to_graph(thermostat_spec, base_uri="https://example.com/")
         ttl = g.serialize(format="turtle")
-        assert "example.com" in ttl
+        assert "https://example.com/" in ttl
 
 
 class TestSystemIRToGraph:


### PR DESCRIPTION
## Summary
- Use full URL `https://example.com/` instead of substring `example.com` in test assertion to satisfy CodeQL's incomplete URL substring sanitization check (line 140 of `test_export.py`)

## Test plan
- [x] Change is in test code only — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)