### PR TITLE
fix: harmonize notation with Zargham & Shorish (2022)

### DIFF
--- a/docs/examples/building-models.md
+++ b/docs/examples/building-models.md
@@ -104,7 +104,7 @@ def build_system():
 | State vs Signal | State persists (Entity). Signals are transient (Space). |
 | Parameter vs Input | Parameters fixed per run (Θ). Inputs vary per step (BoundaryAction). |
 | Which operator | Linear → `>>`. Independent → `\|`. Backward → `.feedback()`. Iteration → `.loop()`. |
-| ControlAction vs Policy | Policy = decision logic (g). ControlAction = admissibility constraint (d). |
+| ControlAction vs Policy | Policy = decision logic g(x, z) → d. ControlAction = output observable y = C(x, d). |
 
 ## Role Constraints
 

--- a/docs/examples/examples/insurance.md
+++ b/docs/examples/examples/insurance.md
@@ -29,13 +29,13 @@ flowchart LR
 
 ## What You'll Learn
 
-- **ControlAction** role — the 4th block role, for admissibility/control decisions
+- **ControlAction** role — the 4th block role, for output observables
 - Complete 4-role taxonomy: BoundaryAction → Policy → ControlAction → Mechanism
-- ControlAction vs Policy: Policy is core decision logic (g), ControlAction constrains the action space (d)
-- `params_used` on ControlAction — parameterized admissibility rules
+- ControlAction vs Policy: Policy is decision logic g(x, z) → d, ControlAction is the output observable y = C(x, d)
+- `params_used` on ControlAction — parameterized output computation
 
 !!! note "Key distinction"
-    Premium Calculation is **ControlAction** because it enforces admissibility constraints — it decides what's *allowed*, not what to do.
+    Premium Calculation is **ControlAction** because it computes an observable output signal — the premium rate that downstream mechanisms consume. It maps state and decisions to an output, rather than making the core risk assessment decision.
 
 ## Files
 

--- a/docs/framework/design/gds-deepdive.md
+++ b/docs/framework/design/gds-deepdive.md
@@ -426,7 +426,7 @@ class Policy(Block):
     named options for A/B testing or scenario analysis.
 
     In GDS terms: policies implement the decision mapping
-    within the admissibility constraint.
+    d = g(x, z) within the canonical form h = f ∘ g.
     """
 
     kind = "policy"

--- a/docs/framework/design/v0.2-design.md
+++ b/docs/framework/design/v0.2-design.md
@@ -45,9 +45,9 @@ h = f ∘ g
 
 Where:
 - **X** — State space (from Entities)
-- **U** — Input space (from BoundaryActions)
+- **Z** — Exogenous signal space (from BoundaryActions)
 - **D** — Decision space (outputs of Policies)
-- **g** — Policy mapping: X × U → D
+- **g** — Policy mapping: X × Z → D
 - **f** — State transition: X × D → X
 
 ### 2.2 Parameter Space Extension
@@ -256,7 +256,7 @@ class CanonicalGDS(BaseModel):
     # Spaces
     X: ProductSpace        # State space (from Entities)
     Theta: ParameterSchema # Parameter space (schema only)
-    U: ProductSpace        # Input space (from BoundaryAction outputs)
+    Z: ProductSpace        # Exogenous signal space (from BoundaryAction outputs)
     D: ProductSpace        # Decision space (from Policy outputs)
 
     # Structural decomposition

--- a/docs/framework/guide/architecture.md
+++ b/docs/framework/guide/architecture.md
@@ -66,7 +66,7 @@ Auto-wiring for `>>` matches `forward_out` ports to `forward_in` ports by token 
 `project_canonical(spec: GDSSpec) → CanonicalGDS` derives the formal GDS decomposition:
 
 - **X** — state space (all Entity variables)
-- **U** — input space (BoundaryAction outputs)
+- **Z** — exogenous signal space (BoundaryAction outputs)
 - **D** — decision space (Policy outputs)
 - **Θ** — parameter space (ParameterSchema)
 - **g** — policy map (BoundaryAction + Policy blocks)

--- a/docs/framework/guide/blocks.md
+++ b/docs/framework/guide/blocks.md
@@ -18,7 +18,7 @@ Block roles subclass `AtomicBlock` and add interface constraints:
 |---|:---:|:---:|:---:|:---:|---|
 | **BoundaryAction** | MUST be `()` | any | any | any | Exogenous observation |
 | **Policy** | any | any | any | any | Decision logic |
-| **ControlAction** | any | any | any | any | Admissibility constraint |
+| **ControlAction** | any | any | any | any | Output observable y = C(x, d) |
 | **Mechanism** | any | any | MUST be `()` | MUST be `()` | State update |
 
 Violating the MUST constraints raises `GDSCompositionError` immediately at construction time.
@@ -56,7 +56,7 @@ controller = Policy(
 
 ### ControlAction
 
-Admissibility constraints — limits what actions are allowed.
+Output observable — the system's observable output `y = C(x, d)` for composition with other systems. From the plant (inside) perspective, this is what the system emits. From the controller (outside) perspective at a `>>` boundary, it becomes a control action on the next system.
 
 ```python
 from gds import ControlAction, interface

--- a/docs/framework/guide/glossary.md
+++ b/docs/framework/guide/glossary.md
@@ -6,10 +6,11 @@ GDS terminology mapped to framework concepts.
 |---|---|---|
 | **State** (x) | The current configuration of the system — a point in the state space | A value held by `StateVariable`s inside an `Entity` |
 | **State Space** (X) | All possible configurations; can be any data structure, not just ℝⁿ | Product of all `Entity` variables, each typed by `TypeDef` |
-| **Input** (u) | An external or agent-chosen action that influences the next state | A signal flowing through `Port`s on a block's `Interface` |
-| **Admissible Input Space** (U_x) | The set of inputs available *given* the current state x | Constraints encoded in `ControlAction` blocks |
-| **Input Map** (g) | Selects an input u from the admissible set — may be a decision-maker or stochastic process | `BoundaryAction` (exogenous) or `Policy` (endogenous) |
-| **State Update Map** (f) | Takes current state and chosen input, produces the next state: f(x, u) → x⁺ | `Mechanism` blocks — the only blocks that write to state |
+| **Exogenous Signal** (z) | An external signal entering the system from outside | `BoundaryAction` outputs flowing through `Port`s. Paper uses u for the selected action; codebase uses z for exogenous signals to avoid conflation. |
+| **Decision** (d) | The output of the policy mapping d = g(x, z) | `Policy` forward_out ports. Corresponds to the paper's selected action u ∈ U_x. |
+| **Admissible Input Space** (U_x) | The set of inputs available *given* the current state x (paper Def 2.5) | Structural skeleton via `AdmissibleInputConstraint`; behavioral constraint requires runtime |
+| **Input Map** (g) | Maps state and exogenous signals to a decision: g(x, z) → d | `Policy` blocks (endogenous decision logic) |
+| **State Update Map** (f) | Takes current state and decision, produces the next state: f(x, d) → x⁺ | `Mechanism` blocks — the only blocks that write to state |
 | **State Transition Map** (h) | The composed pipeline h = f\|_x ∘ g — one full step of the system | The wiring produced by `>>` composition |
 | **Trajectory** (x₀, x₁, ...) | A sequence of states produced by repeatedly applying h | Temporal iteration via `.loop()` |
 | **Reachability** | Can the system reach state y from state x through some sequence of inputs? | `check_reachability()` in the verification engine |

--- a/docs/framework/guide/pipeline.md
+++ b/docs/framework/guide/pipeline.md
@@ -396,10 +396,10 @@ The canonical projection classifies every registered block by its role:
 
 | Role | Maps to | Canonical component |
 |------|---------|---------------------|
-| `BoundaryAction` | Input space U | Exogenous inputs |
-| `Policy` | Decision space D | g: X x U --> D |
+| `BoundaryAction` | Exogenous signal space Z | Exogenous inputs |
+| `Policy` | Decision space D | g: X x Z --> D |
 | `Mechanism` | State transition | f: X x D --> X |
-| `ControlAction` | (unused) | -- |
+| `ControlAction` | Output space Y | Output observable y = C(x, d) |
 
 `project_canonical()` operates on `GDSSpec`, not `SystemIR`, because it needs role information and entity definitions. It is deterministic, stateless, and never mutates the spec. The `CanonicalGDS` result is frozen (immutable).
 

--- a/docs/research/formal-representability.md
+++ b/docs/research/formal-representability.md
@@ -203,9 +203,9 @@ pi : GDSSpec -> CanonicalGDS yields:
 C = (X, U, D, Theta, g, f, h, A_deps, R_deps)
 
 X      = product_{(e,v) in E} TypeDef(e.variables[v])    state space
-U      = {(b, p) : b in B_boundary, p in b.forward_out}  input space
+Z      = {(b, p) : b in B_boundary, p in b.forward_out}  exogenous signal space
 D      = {(b, p) : b in B_policy, p in b.forward_out}    decision space
-g      : X x U -> D                                       policy mapping
+g      : X x Z -> D                                       policy mapping
 f      : X x D -> X                                       state transition
 h_theta: X -> X  where  h = f ∘ g                         composed transition
 A_deps = {(name, {(e,v)}) : ac in A}                      admissibility dependencies
@@ -774,7 +774,7 @@ tier based on what it requires:
 | State evolution over time | Dynamic temporal | gds-sim execution | Requires evaluating f repeatedly |
 | Constraint satisfaction | Dynamic behavioral | TypeDef.constraint() | General case: Rice's theorem |
 | Auto-wiring computation | Dynamic structural | tokenize() + overlap | String parsing exceeds SPARQL |
-| Actual signal propagation | Dynamic behavioral | simulation with concrete values | Requires computing g(x, u) |
+| Actual signal propagation | Dynamic behavioral | simulation with concrete values | Requires computing g(x, z) |
 | Scheduling/delay semantics | Dynamic temporal | execution model | Not stored in GDS — external |
 | Equilibrium computation | Dynamic strategic | game solvers | Computing Nash equilibria is PPAD-complete |
 

--- a/docs/research/paper-implementation-gap.md
+++ b/docs/research/paper-implementation-gap.md
@@ -19,10 +19,10 @@
 | State Space (Def 2.1) | X | `Entity` + `StateVariable`; X = product of all entity variables | Product structure is explicit |
 | State (Def 2.2) | x in X | Dict of entity -> variable -> value | At runtime only (gds-sim) |
 | Trajectory (Def 2.3) | x_0, x_1, ... | gds-sim trajectory execution | Deferred to simulation package |
-| Input Space (Def 2.4) | U | `BoundaryAction.forward_out` ports | Structural only |
-| Input (Def 2.4) | u in U | Signal on boundary port | At runtime only |
+| Input Space (Def 2.4) | U (paper) / Z (codebase) | `BoundaryAction.forward_out` ports | Structural only. Codebase uses Z for exogenous signals to avoid conflation with the paper's u (selected action). |
+| Input (Def 2.4) | u in U (paper) / z in Z (codebase) | Signal on boundary port | At runtime only |
 | State Update Map (Def 2.6) | f : X x U_x -> X | `Mechanism` blocks with `updates` field | Structural skeleton only -- f_struct (which entity/variable) is captured, f_behav (the function) is not stored |
-| Input Map (Def 2.8) | g : X -> U_x | `Policy` blocks | Same: structural identity only |
+| Input Map (Def 2.8) | g : X -> U_x (paper) / g : X x Z -> D (codebase) | `Policy` blocks | Same: structural identity only. Codebase interposes explicit decision space D and exogenous signals Z. |
 | State Transition Map (Def 2.9) | h = f\|_x . g | `project_canonical()` computes formula | Declared composition, not executable |
 | GDS (Def 2.10) | {h, X} | `CanonicalGDS` dataclass | Faithful for structural identity |
 
@@ -79,9 +79,9 @@ h(x) = f(x, g(x))      (autonomous after g is fixed)
 
 **Software:**
 ```
-g : X x U -> D          (policy: state x exogenous input -> decisions)
+g : X x Z -> D          (policy: state x exogenous signals -> decisions)
 f : X x D -> X          (mechanism: state x decisions -> next state)
-h(x) = f(x, g(x, u))   (not autonomous -- exogenous U remains)
+h(x) = f(x, g(x, z))   (not autonomous -- exogenous Z remains)
 ```
 
 Key differences:

--- a/docs/research/research-boundaries.md
+++ b/docs/research/research-boundaries.md
@@ -17,7 +17,7 @@ Six independent DSLs now compile to the same algebraic core:
 All three reduce to the same canonical form without modification:
 
 ```
-d = g(x, u)
+d = g(x, z)
 x' = f(x, d)
 ```
 
@@ -160,7 +160,7 @@ At the IR level, all temporal wirings are identical:
 source → target (temporal, covariant)
 ```
 
-Canonical treats recurrence purely algebraically — `x' = f(x, g(x, u))` — without encoding evaluation scheduling, delay, or sampling semantics.
+Canonical treats recurrence purely algebraically — `x' = f(x, g(x, z))` — without encoding evaluation scheduling, delay, or sampling semantics.
 
 This is correct structurally. But it is incomplete for execution.
 
@@ -172,7 +172,7 @@ This is correct structurally. But it is incomplete for execution.
 
 All current DSLs assume synchronous discrete-time execution (Moore-style):
 
-1. Compute `d = g(x[t], u[t])`
+1. Compute `d = g(x[t], z[t])`
 2. Compute `x[t+1] = f(x[t], d)`
 3. All observation and control occur within one step
 
@@ -208,7 +208,7 @@ Without explicit execution semantics, different DSLs may assume incompatible tim
 Define execution directly from canonical:
 
 ```python
-d = g(x, u)       # observation + decision
+d = g(x, z)       # observation + decision
 x_next = f(x, d)  # state update
 ```
 

--- a/improvement-plans/review_synthesis.md
+++ b/improvement-plans/review_synthesis.md
@@ -1,0 +1,166 @@
+# Synthesis of GDS-Core Reviews: Zargham vs. Jamsheed
+
+**Date:** 2026-04-03
+**Sources:**
+- `gds_core_briefing.md`, `gds_core_improvement_roadmap.md`, `gds_core_risk_register_and_doctrines.md` — Engineering review (Zargham + Claude understudy)
+- `math-review.md` — Mathematical review (Jamsheed)
+
+---
+
+## Executive Summary
+
+Both reviews validate the theoretical foundation but identify critical gaps in notation alignment with the paper, `ControlAction` semantics, and temporal agnosticism documentation. Jamsheed focuses on mathematical formalism fidelity to Zargham & Shorish (2022); Zargham provides a 14-item engineering roadmap with risks and doctrines. Their recommendations are ~85% aligned, with minor divergences on tier ordering.
+
+---
+
+## Where the Reviews Agree
+
+### 1. ControlAction = Output Map (Not Admissibility Constraint)
+
+| Review | Finding |
+|--------|---------|
+| **Zargham T0-3** | `ControlAction` is unused by all six DSLs; should be `y = C(x,d)` for controller-plant duality |
+| **Jamsheed** | "erroneously referred to in the codebase as 'admissibility constraint'" — should be output observable for composition |
+
+**Consensus:** Same signal `y` is:
+- **Inside perspective:** plant's output map
+- **Outside perspective:** control action on the next system
+
+### 2. Notation Must Harmonize with Paper
+
+| Issue | Codebase | Paper/Bosch | Fix |
+|-------|----------|-------------|-----|
+| External factors | `u` | `z` (or `varepsilon`) | Rename to `z` or distinct from action `u` |
+| "Input Space U" | Used for external factors | `U_x` is admissible input space | Clarify terminology |
+| Policy mapping | `g(x,u)` | `g(x)` or `g(x,z)` | Align with paper's intent |
+
+### 3. Core is Time-Agnostic (Structural Recurrence)
+
+| Review | Framing |
+|--------|---------|
+| **Zargham T0-4** | "Core is time-agnostic" — `is_temporal=True` is structural boundary marker only |
+| **Jamsheed** | "Structural recurrence primitive regardless of `is_temporal`" — uses semigroup `(N, +)` for sequencing |
+
+**Consensus:** The three-layer temporal stack:
+- Layer 0 (core): Structural recurrence only — no time model
+- Layer 1 (DSL): `ExecutionContract` declares time model
+- Layer 2 (sim): Solver/runner implements time model
+
+### 4. Representation-Agnostic Architecture
+
+Both confirm the core should not commit to numerical, relational, or any substrate. Arithmetic enters at DSL layer.
+
+---
+
+## Where the Reviews Diverge
+
+### Tier Ordering Disagreements
+
+| Item | Zargham's Tier | Jamsheed's View |
+|------|---------------|-----------------|
+| **Continuous-time formalization** | Tier 2 (medium priority) | Move to Tier 1 — "ambitious objective... many limit conceptions possible" |
+| **Stochastic extensions** | Tier 3 (research frontier) | "Most crucial... could be Tier in own right or Tier 2" |
+| **Discrete-time framework** | Moore as default in T1-1 | Elevate Mealy machines — "Mealy includes Moore as subclass" |
+
+### Scope Differences
+
+| Aspect | Zargham | Jamsheed |
+|--------|---------|----------|
+| **Primary output** | 14-item roadmap with risks/doctrines | Mathematical corrections + architectural feedback |
+| **ControlAction taxonomy** | Deep dive on controller-plant duality, perspective inversion, observability connection | Suggests `Output`/`OutputObservable` class with typing for plant vs control action |
+| **Time agnosticism** | Three-layer stack with formal invariant | Emphasizes "before/after" semantic structure; notes OGS proves degenerate case works |
+
+---
+
+## The Criticisms: A Taxonomy
+
+### Tier 0 (Must Fix Before Anything Else)
+
+| ID | Issue | Severity | Reviews Citing |
+|----|-------|----------|---------------|
+| T0-1 | Checks lack formal property statements | **Critical** | Zargham (C1 violation) |
+| T0-2 | Tests lack requirement traceability | **Critical** | Zargham (C1, C3) |
+| T0-3 | `ControlAction` role unresolved | **Critical** | **Both** — Zargham's T0-3, Jamsheed's General Comments |
+| T0-4 | Temporal agnosticism not formally stated | **Critical** | **Both** — Zargham's T0-4, Jamsheed's time agnosticism section |
+
+### Documentation Issues
+
+| Issue | Jamsheed's Words | Zargham's Mitigation |
+|-------|------------------|---------------------|
+| `ControlAction` misnamed | "erroneously referred to... as admissibility constraint" | T0-3 deliverable 2: dedicated duality documentation page |
+| Input space conflation | "erroneously referred to as the 'Input Space U'" | OC-6: distinct categories for `U_c`, `W`, `D`, `Y` |
+| Discrete-time bias | "documentation quietly undermines [time agnosticism]" | T0-4 deliverable 3: audit + correction of trajectory notation |
+
+### Ontological Commitments
+
+Jamsheed's review confirms Zargham's OC-1 through OC-10 but adds nuance:
+
+> "Generalized refers to general data structures (representation generality, architecture principle 1), while dynamical refers to both the trajectory sequencing and its computational implementability (architecture principles 2 and 3)."
+
+This directly validates Zargham's:
+- OC-3 (Space as compatibility token — "generalized")
+- OC-7 (Structural recurrence — "dynamical")
+- OC-10 (Simulation is instrumentation — "computational implementability")
+
+---
+
+## Actionable Steps: Unified Priority
+
+### Immediate (Tier 0 — No New Code)
+
+**1. T0-3: Resolve ControlAction** — Both reviews agree this is foundational
+- Formalize `y = C(x,d)` as output map
+- Document controller-plant duality with thermostat example
+- Add `(Y, C)` to canonical projection
+- Create SC-check preventing ControlAction in `g` pathway
+
+**2. Notation Harmonization** — Jamsheed's math review + Zargham's OC-6
+- External factors: change `u` to `z` (or distinct symbol)
+- Rename "Input Space U" to "External Factor Space Z"
+- Policy: clarify `g(x)` vs `g(x,z)` vs `g(x,u_c)` with controlled inputs
+
+**3. T0-4: Formalize Temporal Agnosticism**
+- State invariant: `is_temporal=True` = structural recurrence only
+- Three-layer stack diagram
+- Audit docs: replace "next step" with "temporal boundary"
+
+### Near-Term (Tier 1)
+
+**4. T1-1: ExecutionContract** — Elevate per Jamsheed's feedback on Mealy machines
+- Add `update_ordering: Literal["Moore", "Mealy"]` field
+- Default remains Moore, but Mealy is explicitly supported
+
+**5. T1-3: Disturbance Inputs** — Resolves Jamsheed's `z` notation concern
+- Formal partition: `U_c` (controlled) vs `W` (disturbance)
+- Tagged mixin: `{"role": "disturbance"}`
+- DST-001 check: disturbance bypasses policy layer
+
+### Medium-Term (Tier 2 — Per Jamsheed's Recommendations)
+
+**6. T2-4: Continuous-Time** — Consider moving to Tier 1 per Jamsheed
+- `SolverInterface` contract separates spec from simulation
+- Scope: real-valued subspaces only (explicit constraint)
+
+**7. Stochastic Extensions** — Jamsheed's "most crucial" item
+- Consider Tier 2 placement (not Tier 3) per Jamsheed's recommendation
+- Requires T1-1 (`ExecutionContract`) and T2-2 (behavioral verification) stable first
+
+---
+
+## Key Architectural Decisions Pending
+
+1. **Should continuous-time formalization move to Tier 1?** Jamsheed argues yes for earlier operationalization; Zargham placed it Tier 2 for scope discipline.
+
+2. **Should stochastic extensions be elevated to Tier 2 (or own Tier)?** Jamsheed sees this as crucial; roadmap currently has it Tier 3.
+
+3. **Mealy vs Moore as discrete-time framework:** Jamsheed suggests elevating Mealy as the general case (Moore as subclass). Currently roadmap has Moore as default with Mealy as option.
+
+4. **External factor notation:** `z` (Bosch presentation), `varepsilon` (past usage), or keep `u` with clear subscripting? Jamsheed flags conflict with action `u`.
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 0.1 | 2026-04-03 | Initial synthesis from both reviews |

--- a/packages/gds-examples/README.md
+++ b/packages/gds-examples/README.md
@@ -294,12 +294,12 @@ claim >> risk >> premium >> payout >> reserve_update
 <details>
 <summary>What you'll learn</summary>
 
-- ControlAction role — the 4th block role, for admissibility/control decisions
+- ControlAction role — the 4th block role, for output observables
 - Complete 4-role taxonomy: BoundaryAction → Policy → ControlAction → Mechanism
-- ControlAction vs Policy: Policy is core decision logic (g), ControlAction constrains the action space (d)
-- params_used on ControlAction — parameterized admissibility rules
+- ControlAction vs Policy: Policy is decision logic g(x, z) → d, ControlAction is the output observable y = C(x, d)
+- params_used on ControlAction — parameterized output computation
 
-**Key distinction:** Premium Calculation is ControlAction because it enforces admissibility constraints — it decides what's allowed, not what to do.
+**Key distinction:** Premium Calculation is ControlAction because it computes an observable output signal — the premium rate that downstream mechanisms consume.
 
 </details>
 

--- a/packages/gds-examples/games/crosswalk/VIEWS.md
+++ b/packages/gds-examples/games/crosswalk/VIEWS.md
@@ -78,7 +78,7 @@ flowchart LR
 Blocks grouped by GDS role — all 4 roles present:
 - **BoundaryAction**: Observe Traffic (exogenous input)
 - **Policy**: Pedestrian Decision (observation -> action)
-- **ControlAction**: Safety Check (admissibility constraint)
+- **ControlAction**: Safety Check (output observable)
 - **Mechanism**: Traffic Transition (Markov state update)
 
 ```mermaid

--- a/packages/gds-examples/games/crosswalk/generate_views.py
+++ b/packages/gds-examples/games/crosswalk/generate_views.py
@@ -70,7 +70,7 @@ def generate_views() -> str:
         "Blocks grouped by GDS role — all 4 roles present:\n"
         "- **BoundaryAction**: Observe Traffic (exogenous input)\n"
         "- **Policy**: Pedestrian Decision (observation -> action)\n"
-        "- **ControlAction**: Safety Check (admissibility constraint)\n"
+        "- **ControlAction**: Safety Check (output observable)\n"
         "- **Mechanism**: Traffic Transition (Markov state update)\n"
     )
     sections.append(f"```mermaid\n{spec_to_mermaid(spec)}\n```\n")

--- a/packages/gds-examples/games/crosswalk/model.py
+++ b/packages/gds-examples/games/crosswalk/model.py
@@ -38,7 +38,7 @@ Concepts Covered:
     - Discrete state spaces with integer-valued TrafficState
     - All 4 block roles: BoundaryAction, Policy, ControlAction, Mechanism
     - Design parameters (Theta) as mechanism design levers
-    - ControlAction for admissibility constraints (safe vs unsafe crossing)
+    - ControlAction as output observable (safety check signal)
     - Markov transition matrix semantics in the mechanism
     - Reachability and controllability as verification outcomes
     - Binary exogenous randomness (luck) as BoundaryAction input

--- a/packages/gds-examples/games/insurance/model.py
+++ b/packages/gds-examples/games/insurance/model.py
@@ -1,15 +1,16 @@
-"""Insurance Contract Model — ControlAction for admissibility.
+"""Insurance Contract Model — ControlAction as output observable.
 
-Demonstrates the ControlAction role, which reads state and emits
-control signals (unlike Mechanism which writes state, and unlike
-BoundaryAction which has no forward inputs).
+Demonstrates the ControlAction role, which maps state and decisions
+to an observable output y = C(x, d) for composition with other systems
+(unlike Mechanism which writes state, and unlike BoundaryAction which
+has no forward inputs).
 
 Concepts Covered:
     - ControlAction role — the 4th and final block role
     - Complete 4-role taxonomy: BoundaryAction, Policy, ControlAction, Mechanism
     - Pure sequential pipeline (no feedback or temporal loops)
     - Mechanism with forward_out for chaining (Claim Payout → Reserve Update)
-    - params_used on ControlAction (Θ for admissibility constraints)
+    - params_used on ControlAction (Θ for output computation)
 
 Prerequisites: sir_epidemic (basic roles, >>)
 
@@ -239,7 +240,7 @@ def build_spec() -> GDSSpec:
     spec.register_block(claim_payout)
     spec.register_block(reserve_update)
 
-    # Parameters — Θ: admissibility constraints for the ControlAction
+    # Parameters — Θ: output computation parameters for the ControlAction
     spec.register_parameter("base_premium_rate", PremiumRate)
     spec.register_parameter("deductible", Currency)
     spec.register_parameter("coverage_limit", Currency)

--- a/packages/gds-framework/README.md
+++ b/packages/gds-framework/README.md
@@ -334,10 +334,11 @@ Blocks with bidirectional typed interfaces, composed via four operators (`>>`, `
 |---|---|---|
 | **State** (x) | The current configuration of the system — a point in the state space | A value held by `StateVariable`s inside an `Entity` |
 | **State Space** (X) | All possible configurations; can be any data structure, not just ℝⁿ | Product of all `Entity` variables, each typed by `TypeDef` |
-| **Input** (u) | An external or agent-chosen action that influences the next state | A signal flowing through `Port`s on a block's `Interface` |
-| **Admissible Input Space** (U_x) | The set of inputs available *given* the current state x | Constraints encoded in `ControlAction` blocks |
-| **Input Map** (g) | Selects an input u from the admissible set — may be a decision-maker or stochastic process | `BoundaryAction` (exogenous) or `Policy` (endogenous) |
-| **State Update Map** (f) | Takes current state and chosen input, produces the next state: f(x, u) → x⁺ | `Mechanism` blocks — the only blocks that write to state |
+| **Exogenous Signal** (z) | An external signal entering the system from outside | `BoundaryAction` outputs flowing through `Port`s. Paper uses u for the selected action; codebase uses z for exogenous signals to avoid conflation. |
+| **Decision** (d) | The output of the policy mapping d = g(x, z) | `Policy` forward_out ports. Corresponds to the paper's selected action u ∈ U_x. |
+| **Admissible Input Space** (U_x) | The set of inputs available *given* the current state x (paper Def 2.5) | Structural skeleton via `AdmissibleInputConstraint`; behavioral constraint requires runtime |
+| **Input Map** (g) | Maps state and exogenous signals to a decision: g(x, z) → d | `Policy` blocks (endogenous decision logic) |
+| **State Update Map** (f) | Takes current state and decision, produces the next state: f(x, d) → x⁺ | `Mechanism` blocks — the only blocks that write to state |
 | **State Transition Map** (h) | The composed pipeline h = f\|_x ∘ g — one full step of the system | The wiring produced by `>>` composition |
 | **Trajectory** (x₀, x₁, ...) | A sequence of states produced by repeatedly applying h | Temporal iteration via `.loop()` |
 | **Reachability** | Can the system reach state y from state x through some sequence of inputs? | `check_reachability()` in the verification engine |

--- a/packages/gds-framework/gds/blocks/roles.py
+++ b/packages/gds-framework/gds/blocks/roles.py
@@ -2,10 +2,10 @@
 
 These roles decompose the transition function h into typed components:
 
-- **BoundaryAction** — exogenous input (GDS admissible inputs U)
-- **ControlAction** — endogenous control (reads state, emits signals)
-- **Policy** — decision logic (maps signals to mechanism inputs)
-- **Mechanism** — state update (the only component that writes state)
+- **BoundaryAction** — exogenous signals entering the system (z ∈ Z)
+- **ControlAction** — output observable y = C(x, d) for inter-system composition
+- **Policy** — decision logic d = g(x, z) mapping signals to mechanism inputs
+- **Mechanism** — state update x' = f(x, d), the only component that writes state
 
 Each role subclasses AtomicBlock, inheriting composition operators and
 flatten(). Role-specific validators enforce structural constraints.
@@ -50,9 +50,9 @@ class HasOptions(Protocol):
 
 
 class BoundaryAction(AtomicBlock):
-    """Exogenous input — enters the system from outside.
+    """Exogenous signal — enters the system from outside.
 
-    In GDS terms: part of the admissible input set U.
+    In GDS terms: part of the exogenous signal space Z.
     Boundary actions model external agents, oracles, user inputs,
     environmental signals — anything the system doesn't control.
 
@@ -76,10 +76,12 @@ class BoundaryAction(AtomicBlock):
 
 
 class ControlAction(AtomicBlock):
-    """Endogenous control — reads state, emits control signals.
+    """Output observable — maps state and decisions to observable output.
 
-    These are internal feedback loops: the system observing itself
-    and generating signals that influence downstream policy/mechanism blocks.
+    In GDS terms: the output map y = C(x, d). From the plant (inside)
+    perspective, this is the system's observable output. From the
+    controller (outside) perspective at a >> composition boundary,
+    this output becomes a control action on the next system.
     """
 
     kind: str = "control"
@@ -95,7 +97,7 @@ class Policy(AtomicBlock):
     scenario analysis and A/B testing.
 
     In GDS terms: policies implement the decision mapping
-    within the admissibility constraint.
+    d = g(x, z) within the canonical form h = f ∘ g.
     """
 
     kind: str = "policy"

--- a/packages/gds-framework/gds/canonical.py
+++ b/packages/gds-framework/gds/canonical.py
@@ -6,11 +6,20 @@ from a GDSSpec:
     h_θ : X → X  where θ ∈ Θ
 
     X = state space (product of entity variables)
-    U = input space (BoundaryAction outputs)
+    Z = exogenous signal space (BoundaryAction outputs)
     D = decision space (Policy outputs)
-    g = policy mapping: X x U → D
+    g = policy mapping: X x Z → D
     f = state transition: X x D → X
     Θ = parameter space (ParameterSchema)
+
+Notation mapping (codebase vs paper):
+    Paper (Zargham & Shorish 2022) uses u ∈ U_x for the selected action
+    and g(x) for the input map. The codebase interposes an explicit
+    decision space D and exogenous signal space Z (external factors):
+        Paper's u (action)  ↔  codebase's d (decision, Policy output)
+        Paper's U_x         ↔  codebase's D (decision space)
+        Paper's g(x)        ↔  codebase's g(x, z)
+        Bosch lectures' z   ↔  codebase's z (exogenous signals)
 
 This is a **pure function** of GDSSpec — always derivable, never authoritative.
 GDSSpec remains ground truth.
@@ -44,7 +53,7 @@ class CanonicalGDS(BaseModel):
     # Parameter space Θ
     parameter_schema: ParameterSchema = Field(default_factory=ParameterSchema)
 
-    # Input space U: (block_name, port_name) from BoundaryAction forward_out
+    # Exogenous signal space Z: (block_name, port_name) from BoundaryAction forward_out
     input_ports: tuple[tuple[str, str], ...] = ()
 
     # Decision space D: (block_name, port_name) from Policy forward_out
@@ -120,7 +129,7 @@ def project_canonical(spec: GDSSpec) -> CanonicalGDS:
         elif isinstance(block, Mechanism):
             mechanism_blocks.append(bname)
 
-    # 4. Input space U: BoundaryAction forward_out ports
+    # 4. Exogenous signal space Z: BoundaryAction forward_out ports
     input_ports: list[tuple[str, str]] = []
     for bname in boundary_blocks:
         block = spec.blocks[bname]

--- a/packages/gds-games/ogs/__init__.py
+++ b/packages/gds-games/ogs/__init__.py
@@ -1,6 +1,6 @@
 """Open Games — Typed DSL for Compositional Game Theory."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from ogs.dsl.base import OpenGame
 from ogs.dsl.compile import compile_to_ir

--- a/packages/gds-stockflow/tests/test_canonical_stress.py
+++ b/packages/gds-stockflow/tests/test_canonical_stress.py
@@ -196,7 +196,7 @@ class TestExogenousEndogenousMixing:
         assert not set(canonical.boundary_blocks) & set(canonical.policy_blocks)
 
     def test_input_ports_from_boundary_only(self, canonical):
-        """Input space U comes exclusively from BoundaryAction forward_out."""
+        """Exogenous signal space Z comes exclusively from BoundaryAction forward_out."""
         input_blocks = {block for block, _port in canonical.input_ports}
         assert input_blocks == set(canonical.boundary_blocks)
 


### PR DESCRIPTION
## Summary

- Harmonizes codebase notation with the paper per Jamsheed's math review
- Renames exogenous signal variable from `u` to `z` (matching Bosch lectures, avoiding conflict with paper's `u` = selected action)
- Fixes ControlAction description from "admissibility constraint" to "output observable `y = C(x, d)`"
- Adds notation mapping table to `canonical.py` documenting codebase vs paper symbol conventions

20 files changed across framework core, docs, examples, and tests. All 1568 tests passing. No public API changes — documentation/comment-level only.

Closes #171

## Changes by category

**Core framework:**
- `canonical.py` — "Input Space U" → "Exogenous signal space Z", added notation mapping
- `roles.py` — updated all role docstrings (BoundaryAction, ControlAction, Policy)

**User-facing docs:**
- `blocks.md`, `architecture.md`, `glossary.md`, `pipeline.md`, `building-models.md`

**Research docs:**
- `research-boundaries.md`, `formal-representability.md`, `paper-implementation-gap.md`

**Examples:**
- Insurance and crosswalk model docstrings, views, READMEs

**Review documents:**
- Added `improvement-plans/review_synthesis.md` (Zargham + Jamsheed synthesis)

## Test plan

- [x] gds-framework: 499 passed
- [x] gds-stockflow: 216 passed
- [x] gds-examples: 853 passed
- [x] ruff lint clean