### PR TITLE
docs: formally state temporal agnosticism and audit temporal language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ Only 5 concrete Block types exist — domain packages subclass `AtomicBlock` onl
 - `AtomicBlock` — leaf node
 - `StackComposition` (`>>`) — sequential, validates token overlap
 - `ParallelComposition` (`|`) — independent, no validation
-- `FeedbackLoop` (`.feedback()`) — backward within timestep, CONTRAVARIANT
-- `TemporalLoop` (`.loop()`) — forward across timesteps, COVARIANT only
+- `FeedbackLoop` (`.feedback()`) — backward within evaluation, CONTRAVARIANT
+- `TemporalLoop` (`.loop()`) — forward across temporal boundaries, COVARIANT only
 
 Block roles (`BoundaryAction`, `Policy`, `Mechanism`, `ControlAction`) subclass `AtomicBlock` and enforce constraints at construction via `@model_validator`.
 

--- a/docs/examples/building-models.md
+++ b/docs/examples/building-models.md
@@ -29,7 +29,7 @@ Count = typedef("Count", int,
 
 ### 2. Define Entities (state space X)
 
-What persists across timesteps.
+What persists across temporal boundaries.
 
 ```python
 from gds import entity, state_var
@@ -40,7 +40,7 @@ agent = entity("Agent",
 
 ### 3. Define Spaces (communication channels)
 
-Transient signals within a timestep — NOT state.
+Transient signals within an evaluation -- NOT state.
 
 ```python
 from gds import space

--- a/docs/examples/examples/lotka-volterra.md
+++ b/docs/examples/examples/lotka-volterra.md
@@ -1,6 +1,6 @@
 # Lotka-Volterra
 
-**Adds temporal loops** — forward iteration across timesteps.
+**Adds temporal loops** -- structural recurrence across temporal boundaries.
 
 ## GDS Decomposition
 
@@ -31,11 +31,11 @@ flowchart TD
 
 ## What You'll Learn
 
-- `.loop()` composition for cross-timestep temporal feedback
+- `.loop()` composition for cross-boundary temporal recurrence
 - **COVARIANT** flow direction — mandatory for `.loop()` (CONTRAVARIANT raises GDSTypeError)
 - Mechanism with `forward_out` — emitting signals after state update
 - `exit_condition` parameter for loop termination
-- Contrast with `.feedback()`: within-timestep vs across-timestep
+- Contrast with `.feedback()`: within-evaluation vs across-boundary
 
 !!! note "Key distinction"
     Temporal wirings must be **COVARIANT** — `.loop()` enforces this at construction time.

--- a/docs/examples/examples/thermostat.md
+++ b/docs/examples/examples/thermostat.md
@@ -1,6 +1,6 @@
 # Thermostat PID
 
-**Adds feedback** — backward information flow within a single timestep.
+**Adds feedback** -- backward information flow within a single evaluation.
 
 ## GDS Decomposition
 

--- a/docs/examples/learning-path.md
+++ b/docs/examples/learning-path.md
@@ -12,13 +12,13 @@ The foundation. Learn TypeDef, Entity, Space, BoundaryAction, Policy, Mechanism,
 
 ### 2. [Thermostat PID](examples/thermostat.md) — Feedback
 
-Adds `.feedback()` for within-timestep backward information flow. Introduces CONTRAVARIANT flow direction and the ControlAction role.
+Adds `.feedback()` for within-evaluation backward information flow. Introduces CONTRAVARIANT flow direction and the ControlAction role.
 
 **New:** `.feedback()`, backward ports, ControlAction
 
 ### 3. [Lotka-Volterra](examples/lotka-volterra.md) — Temporal Loops
 
-Adds `.loop()` for cross-timestep iteration. Introduces COVARIANT temporal wiring and Mechanism with `forward_out`.
+Adds `.loop()` for cross-boundary recurrence. Introduces COVARIANT temporal wiring and Mechanism with `forward_out`.
 
 **New:** `.loop()`, temporal wiring, exit conditions
 

--- a/docs/framework/design/gds-deepdive.md
+++ b/docs/framework/design/gds-deepdive.md
@@ -507,7 +507,7 @@ class Entity:
         X = Entity_1.state × Entity_2.state × ... × Entity_n.state
 
     Entities correspond to actors, resources, registries —
-    anything that persists across timesteps and has mutable state.
+    anything that persists across temporal boundaries and has mutable state.
     """
 
     def __init__(

--- a/docs/framework/design/proposals/entity-redesign.md
+++ b/docs/framework/design/proposals/entity-redesign.md
@@ -169,7 +169,7 @@ Entity = (name, X, U, Y, Θ, θ, P, annotations)
 ```
 
 Where:
-- **X** = state space — persistent across timesteps
+- **X** = state space — persistent across temporal boundaries
 - **U** = input space — signals the entity receives
 - **Y** = output space — signals the entity emits
 - **Θ** = parameter space — configuration dimensions, fixed per trajectory
@@ -782,7 +782,7 @@ u_i = boundary_i(y_j, y_k, ..., e)
 
 Entity i's input (u_i) is assembled from the outbound signals (y_j, y_k, ...) of other entities plus any truly exogenous input (e) from outside the system. The BoundaryAction captures this assembly.
 
-The coupling topology is a directed graph: an edge from entity j to entity i means j's ControlAction output feeds i's BoundaryAction input. This graph is derivable from the composition algebra — `>>` creates sequential coupling, `|` creates independent entities, `.feedback()` creates bidirectional coupling within a timestep, `.loop()` creates temporal coupling across timesteps.
+The coupling topology is a directed graph: an edge from entity j to entity i means j's ControlAction output feeds i's BoundaryAction input. This graph is derivable from the composition algebra — `>>` creates sequential coupling, `|` creates independent entities, `.feedback()` creates bidirectional coupling within an evaluation, `.loop()` creates temporal coupling across temporal boundaries.
 
 ### The Global Dynamical System
 

--- a/docs/framework/design/temporal-agnosticism.md
+++ b/docs/framework/design/temporal-agnosticism.md
@@ -1,0 +1,78 @@
+# Temporal Agnosticism of the Core Algebra
+
+## Invariant Statement
+
+> The composition algebra of gds-framework is temporally agnostic. The flag `is_temporal=True` on a wiring asserts structural recurrence and nothing else. No time model is implied or required by the core. The canonical form h = f . g is an atemporal map. Time models are DSL-layer declarations.
+
+## Three-Layer Temporal Stack
+
+```
+Layer 0 — gds-framework (core)
+  is_temporal=True encodes structural recurrence only:
+  "a temporal boundary exists here."
+  No commitment to what model of time governs that boundary.
+  h = f . g is a single atemporal map application.
+  The algebra is silent on discrete steps, continuous flow, and events.
+
+Layer 1 — DSL (ExecutionContract)
+  The DSL declares what "temporal boundary" means for its domain:
+    discrete    — boundary is a discrete index step
+    continuous  — boundary is a continuous-time interval
+    event       — boundary is triggered by a discrete event
+    atemporal   — boundary carries no time semantics (e.g., OGS iterated games)
+  This is the DSL author's commitment, not the core's.
+
+Layer 2 — Simulation (SolverInterface / runner)
+  Required only to execute a specification.
+  A solver or runner instantiates the time model concretely.
+  The choice of solver (RK4, event queue, discrete stepper) is
+  simulation-layer, not specification-layer.
+  Specification and verification are fully valid without a solver.
+```
+
+## Proof by Inspection of Composition Operators
+
+None of the four composition operators introduce a time model. They operate on structural interfaces only.
+
+**StackComposition (`>>`)** chains `forward_out` to `forward_in` by token overlap. No temporal concept is referenced. The validator checks token sets, not time indices.
+
+**ParallelComposition (`|`)** concatenates interfaces. No validation is performed between left and right. Time is not mentioned.
+
+**FeedbackLoop (`.feedback()`)** routes `backward_out` to `backward_in` within a single evaluation. The wiring direction is `CONTRAVARIANT`. No time model is assumed -- "within a single evaluation" means "before the current map application completes," not "within a discrete timestep."
+
+**TemporalLoop (`.loop()`)** routes `forward_out` to `forward_in` across evaluations. The wiring direction must be `COVARIANT`. The `is_temporal` flag is set on the resulting `WiringIR` edges. This flag tells the acyclicity checker (G-006) to exclude those edges from the covariant DAG constraint. It carries no semantic content about what kind of time governs the recurrence -- it is a structural recurrence marker only.
+
+The `is_temporal` flag exists so that G-006 can distinguish "this edge closes a recurrence" from "this edge creates an illegal cycle." That is its entire semantics at Layer 0.
+
+## The OGS Existence Proof
+
+OGS (Open Game Specification) iterated games compile and verify correctly with temporal wirings but no time model. The canonical form degenerates to h = g with X = empty, f = empty. This is not a special case -- it is existence proof that the algebra is genuinely time-agnostic.
+
+An OGS `IteratedGame` wraps a `OneShot` game with `.loop()` temporal wirings that carry strategy and payoff signals across rounds. The word "round" here is a game-theoretic concept, not a time concept. No discrete-time index, no continuous-time interval, and no event trigger is declared at the core level. The temporal wirings assert only: "there is structural recurrence here."
+
+This demonstrates that the core algebra supports recurrence patterns that have nothing to do with physical time. The `.loop()` operator is about structural feedback topology, not about clocks.
+
+## ExecutionContract Time Model Table
+
+| time_domain | Meaning at DSL layer | Example DSL |
+|---|---|---|
+| discrete | Temporal boundary is a discrete index step | gds-stockflow, gds-control |
+| continuous | Temporal boundary is a continuous-time interval | gds-continuous |
+| event | Temporal boundary is triggered by an event | (future) |
+| atemporal | Temporal boundary carries no time semantics | gds-games (OGS) |
+
+## Vocabulary Guide
+
+When writing documentation for the core framework (Layer 0), use temporally neutral language:
+
+| Avoid (core docs) | Prefer |
+|---|---|
+| "within a single timestep" | "within a single evaluation" |
+| "across timesteps" | "across temporal boundaries" |
+| "next step" / "next timestep" | "subsequent application" or "recurrence" |
+| "time t" / "t+1" subscripts | "evaluation k" / "k+1" (or omit indices) |
+| "trajectory x_0, x_1, ..." | "sequence of states under repeated application of h" |
+| "iteration" (implying counting) | "recurrence" or "repeated application" |
+
+!!! note "DSL-layer exception"
+    DSL-layer docs (gds-stockflow, gds-control, gds-continuous, gds-games) **may** use time-specific language because they have declared a time model via their `ExecutionContract`. The vocabulary guide applies only to core framework documentation.

--- a/docs/framework/getting-started/quickstart.md
+++ b/docs/framework/getting-started/quickstart.md
@@ -51,8 +51,8 @@ print(f"{report.checks_passed}/{report.checks_total} checks passed")
 |---|---|---|---|
 | `>>` | Sequential | Forward | Pipeline stages |
 | `\|` | Parallel | Independent | Concurrent updates |
-| `.feedback()` | Feedback | Backward (within timestep) | Cost signals, constraints |
-| `.loop()` | Temporal | Forward (across timesteps) | Iteration, convergence |
+| `.feedback()` | Feedback | Backward (within evaluation) | Cost signals, constraints |
+| `.loop()` | Temporal | Forward (across temporal boundaries) | Recurrence, convergence |
 
 ## Next Steps
 

--- a/docs/framework/guide/architecture.md
+++ b/docs/framework/guide/architecture.md
@@ -18,6 +18,26 @@ Domain judgment enters at Layer 1: when a modeler decides "this is a Mechanism, 
 
 This separation means Layer 0 specifications stay verifiable without knowing anything about the domain — they can be composed and checked formally. Layer 1 adds the meaning that makes a specification useful for a particular problem.
 
+## Temporal Stack
+
+The core algebra is temporally agnostic. The flag `is_temporal=True` on a wiring asserts structural recurrence -- nothing about discrete steps, continuous flow, or events. Time models are DSL-layer declarations.
+
+```
+Layer 0 — gds-framework (core)
+  is_temporal=True encodes structural recurrence only.
+  h = f . g is a single atemporal map application.
+
+Layer 1 — DSL (ExecutionContract)
+  The DSL declares what "temporal boundary" means:
+    discrete | continuous | event | atemporal
+
+Layer 2 — Simulation (SolverInterface / runner)
+  A solver instantiates the time model concretely.
+  Specification and verification are valid without a solver.
+```
+
+See the full treatment in the [Temporal Agnosticism](../design/temporal-agnosticism.md) design document.
+
 ## Foundation + Domain Packages
 
 ```

--- a/docs/framework/guide/blocks.md
+++ b/docs/framework/guide/blocks.md
@@ -7,8 +7,8 @@ The composition algebra is **sealed** — only 5 concrete Block types exist:
 - `AtomicBlock` — leaf node (domain packages subclass this)
 - `StackComposition` (`>>`) — sequential, validates token overlap
 - `ParallelComposition` (`|`) — independent, no type validation
-- `FeedbackLoop` (`.feedback()`) — backward within timestep
-- `TemporalLoop` (`.loop()`) — forward across timesteps, enforces COVARIANT only
+- `FeedbackLoop` (`.feedback()`) — backward within evaluation
+- `TemporalLoop` (`.loop()`) — forward across temporal boundaries, enforces COVARIANT only
 
 ## GDS Roles
 
@@ -118,7 +118,7 @@ system = pipeline.feedback([
 ])
 ```
 
-Within-timestep backward flow. Requires CONTRAVARIANT direction.
+Within-evaluation backward flow. Requires CONTRAVARIANT direction.
 
 ### Temporal Loop (`.loop()`)
 
@@ -132,7 +132,7 @@ system = pipeline.loop([
 ])
 ```
 
-Cross-timestep forward flow. COVARIANT is mandatory — CONTRAVARIANT raises `GDSTypeError`.
+Cross-boundary forward flow. COVARIANT is mandatory -- CONTRAVARIANT raises `GDSTypeError`.
 
 ## Tagged Mixin
 

--- a/docs/framework/guide/composition.md
+++ b/docs/framework/guide/composition.md
@@ -10,8 +10,8 @@ These operators are domain-neutral — they work identically whether you're comp
 |---|---|---|---|---|
 | **Stack** | `a >> b` | `StackComposition` | Token overlap (auto) or explicit wiring | Sequential data flow |
 | **Parallel** | `a \| b` | `ParallelComposition` | None | Independent side-by-side blocks |
-| **Feedback** | `a.feedback(wiring)` | `FeedbackLoop` | Wiring should be CONTRAVARIANT (not enforced) | Backward signals within a timestep |
-| **Temporal Loop** | `a.loop(wiring)` | `TemporalLoop` | Wiring must be COVARIANT | Forward signals across timesteps |
+| **Feedback** | `a.feedback(wiring)` | `FeedbackLoop` | Wiring should be CONTRAVARIANT (not enforced) | Backward signals within an evaluation |
+| **Temporal Loop** | `a.loop(wiring)` | `TemporalLoop` | Wiring must be COVARIANT | Forward signals across temporal boundaries |
 
 All four operators return a new `Block`, so they can be chained and nested freely. The result is always a tree of composition nodes with `AtomicBlock` leaves.
 
@@ -254,7 +254,7 @@ stock_tier = parallel_tier([update_s, update_i, update_r])
 
 ## Feedback Loop (`.feedback()`)
 
-Feedback wraps a block (or composition) with backward signals that flow within a single timestep. This models intra-step feedback — information that propagates backward through the system before the timestep completes.
+Feedback wraps a block (or composition) with backward signals that flow within a single evaluation. This models intra-evaluation feedback -- information that propagates backward through the system before the current evaluation completes.
 
 ```python
 from gds import Wiring
@@ -283,7 +283,7 @@ graph LR
 
 ### Contravariant Direction
 
-Feedback wirings carry signals **backward** — from outputs to inputs within the same timestep. The wiring direction should be `FlowDirection.CONTRAVARIANT` to reflect this backward flow.
+Feedback wirings carry signals **backward** -- from outputs to inputs within the same evaluation. The wiring direction should be `FlowDirection.CONTRAVARIANT` to reflect this backward flow.
 
 !!! note "Not enforced at construction"
     Unlike `TemporalLoop` which **rejects** non-COVARIANT wirings at construction time, `FeedbackLoop` does not validate the direction. Using CONTRAVARIANT is a convention that correctly reflects the semantics, but passing COVARIANT will not raise an error.
@@ -314,7 +314,7 @@ assert fb.interface == inner.interface  # True
 
 ## Temporal Loop (`.loop()`)
 
-Temporal loops connect a block's outputs to its inputs across timesteps. This is how state persists — the output of timestep `t` becomes the input of timestep `t+1`.
+Temporal loops connect a block's outputs to its inputs across temporal boundaries. This is how state persists -- the output of one evaluation becomes the input of the subsequent application.
 
 ```python
 system = pipeline.loop(
@@ -335,11 +335,11 @@ system = pipeline.loop(
 
 ```mermaid
 graph LR
-    subgraph "Timestep t"
+    subgraph "Evaluation k"
         O["Observe"] -->|"Signal"| D["Decide"]
         D -->|"Action"| U["Update Prey"]
     end
-    U -.->|"Population (t → t+1)"| O
+    U -.->|"Population (recurrence)"| O
 
     style U fill:#bbf,stroke:#333
 ```
@@ -368,7 +368,7 @@ GDSTypeError: TemporalLoop 'A >> B [loop]': temporal wiring
 B.Command → A.Temperature must be COVARIANT (got contravariant)
 ```
 
-The rationale: temporal loops carry state forward in time. Backward-in-time information flow is not physically meaningful for state evolution. Use `.feedback()` instead for within-timestep backward signals.
+The rationale: temporal loops carry state forward across recurrence boundaries. Backward information flow is not structurally meaningful for state evolution. Use `.feedback()` instead for within-evaluation backward signals.
 
 ### Exit Condition
 
@@ -416,8 +416,8 @@ w = Wiring(
 |---|---|---|
 | Ports share tokens | `a >> b` | No — auto-wired |
 | Ports use different vocabularies | `StackComposition(wiring=[...])` | Yes |
-| Backward feedback within timestep | `.feedback(wiring)` | Yes — always explicit |
-| State carried across timesteps | `.loop(wiring)` | Yes — always explicit |
+| Backward feedback within evaluation | `.feedback(wiring)` | Yes — always explicit |
+| State carried across temporal boundaries | `.loop(wiring)` | Yes — always explicit |
 
 Auto-wiring only applies to `>>` (stack composition). All other operators require explicit `Wiring` objects.
 

--- a/docs/framework/guide/glossary.md
+++ b/docs/framework/guide/glossary.md
@@ -12,7 +12,7 @@ GDS terminology mapped to framework concepts.
 | **Input Map** (g) | Maps state and exogenous signals to a decision: g(x, z) → d | `Policy` blocks (endogenous decision logic) |
 | **State Update Map** (f) | Takes current state and decision, produces the next state: f(x, d) → x⁺ | `Mechanism` blocks — the only blocks that write to state |
 | **State Transition Map** (h) | The composed pipeline h = f\|_x ∘ g — one full step of the system | The wiring produced by `>>` composition |
-| **Trajectory** (x₀, x₁, ...) | A sequence of states produced by repeatedly applying h | Temporal iteration via `.loop()` |
+| **Trajectory** | A sequence of states under repeated application of h | Structural recurrence via `.loop()` |
 | **Reachability** | Can the system reach state y from state x through some sequence of inputs? | `check_reachability()` in the verification engine |
 | **Controllability** | Can the system be steered to a target state from any nearby initial condition? | Formal property checked at the spec level |
 | **Configuration Space** | The subset of X where every point is reachable from some initial condition | Characterized by transitive closure over the wiring graph |

--- a/docs/framework/guide/pipeline.md
+++ b/docs/framework/guide/pipeline.md
@@ -25,7 +25,7 @@ These paths are independent. You can compile without a `GDSSpec`, and you can ru
 
 ## Step 1: Define Your Domain
 
-Every GDS model starts with domain definitions: what types of data exist, what communication channels carry them, and what stateful entities persist across timesteps.
+Every GDS model starts with domain definitions: what types of data exist, what communication channels carry them, and what stateful entities persist across temporal boundaries.
 
 ```python
 from gds import typedef, space, entity, state_var
@@ -35,11 +35,11 @@ Temperature = typedef("Temperature", float, units="K")
 Command = typedef("Command", float)
 Energy = typedef("Energy", float, constraint=lambda x: x >= 0)
 
-# Spaces -- typed communication channels (transient within a timestep)
+# Spaces -- typed communication channels (transient within an evaluation)
 sensor_space = space("SensorSpace", measured_temp=Temperature)
 command_space = space("CommandSpace", heater_command=Command)
 
-# Entities -- stateful objects that persist across timesteps (the state space X)
+# Entities -- stateful objects that persist across temporal boundaries (the state space X)
 room = entity("Room",
     temperature=state_var(Temperature, symbol="T"),
     energy_consumed=state_var(Energy, symbol="E"),
@@ -122,8 +122,8 @@ Compose blocks into a tree using four operators:
 |----------|--------|---------|
 | Sequential | `a >> b` | Output of `a` feeds input of `b` |
 | Parallel | `a \| b` | Side-by-side, no shared wires |
-| Feedback | `a.feedback(wiring)` | Backward flow within a timestep |
-| Temporal | `a.loop(wiring)` | Forward flow across timesteps |
+| Feedback | `a.feedback(wiring)` | Backward flow within an evaluation |
+| Temporal | `a.loop(wiring)` | Forward flow across temporal boundaries |
 
 ```python
 # Build the composition tree
@@ -248,7 +248,7 @@ The six generic checks:
 | G-003 | Direction consistency | No COVARIANT+feedback or CONTRAVARIANT+temporal contradictions; contravariant port-slot matching |
 | G-004 | Dangling wirings | All wiring endpoints reference blocks or inputs that exist in the system |
 | G-005 | Sequential type compatibility | Stack wiring labels are token-subsets of BOTH source output AND target input |
-| G-006 | Covariant acyclicity | The covariant (within-timestep) flow graph is a DAG |
+| G-006 | Covariant acyclicity | The covariant (within-evaluation) flow graph is a DAG |
 
 You can also run a subset of checks:
 

--- a/docs/framework/guide/spec.md
+++ b/docs/framework/guide/spec.md
@@ -53,7 +53,7 @@ spec.register_wiring(
 
 ## Entities & State
 
-Entities define the state space X — what persists across timesteps.
+Entities define the state space X -- what persists across temporal boundaries.
 
 ```python
 from gds import entity, state_var, typedef
@@ -69,7 +69,7 @@ room = entity("Room",
 
 ## Spaces
 
-Spaces define typed communication channels — transient signals within a timestep.
+Spaces define typed communication channels -- transient signals within an evaluation.
 
 ```python
 from gds import space

--- a/docs/framework/guide/verification.md
+++ b/docs/framework/guide/verification.md
@@ -313,13 +313,13 @@ system = SystemIR(
 
 **What it checks:** The covariant (forward) flow graph must be a directed acyclic
 graph (DAG). A cycle in the covariant graph means an algebraic loop within a
-single timestep — Block A depends on Block B which depends on Block A, with no
-temporal delay to break the cycle.
+single evaluation -- Block A depends on Block B which depends on Block A, with no
+recurrence boundary to break the cycle.
 
 **Severity:** ERROR
 
 **Excludes:** Temporal wirings (`is_temporal=True`) and contravariant wirings.
-These are legitimate backward or cross-timestep connections that do not create
+These are legitimate backward or cross-boundary connections that do not create
 algebraic loops.
 
 **Detection method:** DFS-based cycle detection on the adjacency graph of

--- a/docs/framework/quick-reference.md
+++ b/docs/framework/quick-reference.md
@@ -299,7 +299,7 @@ inputs = boundary_a | boundary_b
 
 ### `block.feedback(wiring)` -- Feedback loop
 
-Backward feedback within a single timestep. Wiring connects `backward_out` to `backward_in`.
+Backward feedback within a single evaluation. Wiring connects `backward_out` to `backward_in`.
 
 ```python
 from gds import Wiring
@@ -318,7 +318,7 @@ system = (policy >> mechanism).feedback([
 
 ### `block.loop(wiring, exit_condition="")` -- Temporal loop
 
-Forward iteration across timesteps. All temporal wiring must be `COVARIANT`.
+Structural recurrence across temporal boundaries. All temporal wiring must be `COVARIANT`.
 
 ```python
 system = (boundary >> policy >> mechanism).loop(

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -168,14 +168,14 @@ Two loop operators serve different purposes:
 
 | Operator | Direction | Timing | Use Case |
 |----------|-----------|--------|----------|
-| `.feedback()` | CONTRAVARIANT | Within timestep | Backward utility/reward signals |
-| `.loop()` | COVARIANT | Across timesteps | State fed back to observers |
+| `.feedback()` | CONTRAVARIANT | Within evaluation | Backward utility/reward signals |
+| `.loop()` | COVARIANT | Across temporal boundaries | State fed back to observers |
 
 ```python
 from gds.blocks.composition import Wiring
 from gds.ir.models import FlowDirection
 
-# Temporal loop: state at time t feeds into observer at time t+1
+# Temporal loop: state from evaluation k feeds into observer at evaluation k+1
 system_with_loop = forward_pipeline.loop(
     [
         Wiring(
@@ -188,7 +188,7 @@ system_with_loop = forward_pipeline.loop(
     ],
 )
 
-# Feedback loop: backward signal within a single timestep
+# Feedback loop: backward signal within a single evaluation
 # Used in game theory for utility/payoff channels
 system_with_feedback = game_pipeline.feedback(
     [
@@ -204,7 +204,7 @@ system_with_feedback = game_pipeline.feedback(
 ```
 
 !!! warning
-    `.feedback()` is **contravariant** -- it flows backward. `.loop()` is **covariant** -- it flows forward across time. Mixing these up will cause G-003 direction consistency failures.
+    `.feedback()` is **contravariant** -- it flows backward. `.loop()` is **covariant** -- it flows forward across temporal boundaries. Mixing these up will cause G-003 direction consistency failures.
 
 ### Parallel Composition for Independent Subsystems
 
@@ -293,7 +293,7 @@ The `>>` operator builds a DAG. Cycles in covariant flow are caught by G-006:
 # Bad: creates a cycle in the covariant flow graph
 a >> b >> c >> a  # G-006 will flag this
 
-# Good: use .loop() for cross-timestep feedback
+# Good: use .loop() for cross-boundary recurrence
 forward = a >> b >> c
 system = forward.loop([...])  # temporal loop, not a cycle
 ```
@@ -489,7 +489,7 @@ query.param_to_blocks()
 | Use the three-tier pattern: boundary >> policy >> mechanism | Create circular sequential compositions |
 | Name ports for clear token overlap | Use generic names like "Signal" everywhere |
 | Start with auto-wiring, fall back to explicit | Use explicit wiring when auto-wiring works |
-| Use `.loop()` for cross-timestep state feedback | Use `.feedback()` for temporal state (it is contravariant) |
+| Use `.loop()` for cross-boundary state recurrence | Use `.feedback()` for temporal state (it is contravariant) |
 | Use Policy for all decision/observation logic | Use ControlAction (unused across all DSLs) |
 | Run verification even on passing models | Skip verification -- subtle issues hide in structure |
 | Separate state mutation (Mechanism) from decisions (Policy) | Put state-updating logic in Policy blocks |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -117,7 +117,7 @@ Extend the minimal model with **observation and control**:
 
 - A **Sensor** (Policy) reads the room temperature
 - A **Controller** (Policy) decides the heat command using a `setpoint` parameter
-- A **TemporalLoop** (`.loop()`) feeds updated temperature back to the sensor across timesteps
+- A **TemporalLoop** (`.loop()`) feeds updated temperature back to the sensor across temporal boundaries
 
 New operators: `|` (parallel composition) and `.loop()` (temporal feedback).
 
@@ -197,7 +197,7 @@ flowchart TD
     Update_Temperature -.Temperature Reading..-> Sensor
 ```
 
-Note the dashed arrow from Update Temperature back to Sensor -- this is the temporal loop (`.loop()`), indicating cross-timestep feedback.
+Note the dashed arrow from Update Temperature back to Sensor -- this is the temporal loop (`.loop()`), indicating structural recurrence across temporal boundaries.
 
 ---
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -166,15 +166,15 @@ WiringIR(source="Ghost", target="B", label="signal", ...)
 
 ### G-006: Covariant Acyclicity
 
-**What it checks:** The covariant (non-temporal, non-contravariant) flow graph must be a DAG -- no cycles within a single timestep.
+**What it checks:** The covariant (non-temporal, non-contravariant) flow graph must be a DAG -- no cycles within a single evaluation.
 
-**When it fails:** Three or more blocks form a cycle via covariant wirings, creating an algebraic loop that cannot be resolved within one timestep.
+**When it fails:** Three or more blocks form a cycle via covariant wirings, creating an algebraic loop that cannot be resolved within one evaluation.
 
 ```
 A -> B -> C -> A  # cycle detected!
 ```
 
-**Fix:** Break the cycle by using `.loop()` (temporal, across timesteps) for one of the edges instead of `>>` (sequential, within timestep).
+**Fix:** Break the cycle by using `.loop()` (temporal, across temporal boundaries) for one of the edges instead of `>>` (sequential, within evaluation).
 
 ---
 
@@ -267,8 +267,8 @@ These are not interchangeable:
 
 | Operator | Direction | Timing | Purpose |
 |----------|-----------|--------|---------|
-| `.feedback()` | CONTRAVARIANT | Within timestep | Backward utility/reward signals |
-| `.loop()` | COVARIANT | Across timesteps | State feedback to observers |
+| `.feedback()` | CONTRAVARIANT | Within evaluation | Backward utility/reward signals |
+| `.loop()` | COVARIANT | Across temporal boundaries | State feedback to observers |
 
 Using `.feedback()` for temporal state feedback will cause G-003 failures.
 

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -82,7 +82,7 @@ system = SystemIR(
 
 ### G-006: Covariant Cycles
 
-Three blocks form a cycle via non-temporal covariant wirings -- an algebraic loop that cannot be resolved within a single timestep.
+Three blocks form a cycle via non-temporal covariant wirings -- an algebraic loop that cannot be resolved within a single evaluation.
 
 ```python
 system = SystemIR(

--- a/docs/guides/view-stratification.md
+++ b/docs/guides/view-stratification.md
@@ -127,7 +127,7 @@ canonical, they must augment it with execution semantics from the domain
 layer. Canonical alone is insufficient for execution. This boundary must
 remain explicit to avoid the illusion that `h = f ∘ g` is a runnable program.
 
-See [RQ2 (timestep semantics)](../research/research-boundaries.md#research-question-2-what-does-a-timestep-mean-across-dsls)
+See [RQ2 (temporal boundary semantics)](../research/research-boundaries.md#research-question-2-what-does-a-timestep-mean-across-dsls)
 and [RQ4 (cross-lens analysis)](../research/research-boundaries.md#research-question-4-cross-lens-analysis-when-equilibrium-and-reachability-disagree).
 
 ### Semantic enrichment must remain opt-in

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -28,8 +28,8 @@ The compiled block graph from `SystemIR`. Shows composition topology with role-b
 **Arrow conventions:**
 
 - Solid arrow `-->` = covariant forward flow
-- Dashed arrow `-.->` = temporal loop (cross-timestep)
-- Thick arrow `==>` = feedback (within-timestep, contravariant)
+- Dashed arrow `-.->` = temporal loop (cross-boundary)
+- Thick arrow `==>` = feedback (within-evaluation, contravariant)
 
 **API:** `system_to_mermaid(system)`
 

--- a/docs/research/formal-representability.md
+++ b/docs/research/formal-representability.md
@@ -155,8 +155,8 @@ The components are:
 - **Morphisms** are Blocks: typed components with bidirectional interfaces
 - **>>** (sequential): first ; second with token-overlap validation
 - **|** (parallel): left tensor right, no shared wires
-- **fb** (feedback): contravariant backward flow within timestep
-- **loop** (temporal): covariant forward flow across timesteps
+- **fb** (feedback): contravariant backward flow within evaluation
+- **loop** (temporal): covariant forward flow across temporal boundaries
 
 **Definition 1.2 (Token System).** Port names carry structural type
 information via tokenization:

--- a/docs/research/verification-plan.md
+++ b/docs/research/verification-plan.md
@@ -53,8 +53,8 @@ monoidal categories out of the box once the algebra is instantiated.
 
 ### 1c. Traced Monoidal Structure
 
-Prove the Joyal-Street-Verity axioms for `fb` (contravariant, within-timestep)
-and `loop` (covariant, across-timestep):
+Prove the Joyal-Street-Verity axioms for `fb` (contravariant, within-evaluation)
+and `loop` (covariant, across-boundary):
 
 | Axiom | Statement |
 |---|---|
@@ -67,8 +67,8 @@ and `loop` (covariant, across-timestep):
 **Approach:** Coq with Interaction Trees library. The two feedback operators
 have different variance, so they require separate trace instances:
 
-- `fb`: contravariant trace (backward ports looped within timestep)
-- `loop`: covariant trace (forward ports carried across timesteps)
+- `fb`: contravariant trace (backward ports looped within evaluation)
+- `loop`: covariant trace (forward ports carried across temporal boundaries)
 
 Hasegawa's correspondence (Conway fixed-point <-> categorical trace) validates
 that `fb` computes within-timestep fixed points soundly.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -16,7 +16,7 @@ Work through the **example models** in order. Each introduces one new concept wh
 |:-:|---------|-------------------|
 | 1 | [SIR Epidemic](../examples/examples/sir-epidemic.md) | Fundamentals — types, entities, spaces, blocks, composition |
 | 2 | [Thermostat PID](../examples/examples/thermostat.md) | Feedback and backward flow |
-| 3 | [Lotka-Volterra](../examples/examples/lotka-volterra.md) | Temporal loops and cross-timestep iteration |
+| 3 | [Lotka-Volterra](../examples/examples/lotka-volterra.md) | Temporal loops and structural recurrence |
 | 4 | [Prisoner's Dilemma](../examples/examples/prisoners-dilemma.md) | Nested composition and multi-entity state |
 | 5 | [Insurance Contract](../examples/examples/insurance.md) | Complete 4-role taxonomy |
 | 6 | [Crosswalk Problem](../examples/examples/crosswalk.md) | Mechanism design and governance parameters |

--- a/docs/viz/guide/views.md
+++ b/docs/viz/guide/views.md
@@ -26,8 +26,8 @@ mermaid = system_to_mermaid(system)
 | Arrow | Meaning |
 |-------|---------|
 | Solid `-->` | Covariant forward flow |
-| Thick `==>` | Contravariant feedback (within-timestep) |
-| Dashed `-.->` | Temporal loop (cross-timestep) |
+| Thick `==>` | Contravariant feedback (within-evaluation) |
+| Dashed `-.->` | Temporal loop (cross-boundary) |
 
 ### Rendered Output
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -382,6 +382,7 @@ nav:
       - DSL Roadmap: guides/dsl-roadmap.md
       - Research Boundaries: research/research-boundaries.md
       - Paper Implementation Gap: research/paper-implementation-gap.md
+      - Temporal Agnosticism: framework/design/temporal-agnosticism.md
       - View Stratification: guides/view-stratification.md
       - Ecosystem: framework/ecosystem.md
       - Semantic Web Integration: research/semantic-web-summary.md

--- a/packages/gds-framework/CLAUDE.md
+++ b/packages/gds-framework/CLAUDE.md
@@ -240,8 +240,8 @@ Block tree -> flatten() -> list[AtomicBlock] -> block_compiler() -> list[BlockIR
 - `AtomicBlock` — leaf node
 - `StackComposition` (`>>`) — sequential, validates token overlap
 - `ParallelComposition` (`|`) — independent
-- `FeedbackLoop` (`.feedback()`) — backward within timestep, CONTRAVARIANT
-- `TemporalLoop` (`.loop()`) — forward across timesteps, COVARIANT only
+- `FeedbackLoop` (`.feedback()`) — backward within evaluation, CONTRAVARIANT
+- `TemporalLoop` (`.loop()`) — forward across temporal boundaries, COVARIANT only
 
 ### Verification
 

--- a/packages/gds-framework/README.md
+++ b/packages/gds-framework/README.md
@@ -131,7 +131,7 @@ Each domain package is a thin layer. The heavy lifting — composition, compilat
 <details>
 <summary><strong>Example: what lives where</strong></summary>
 
-Consider modeling a **Lotka-Volterra predator-prey system** as a GDS. The state space is (prey_population, predator_population). Each timestep: the environment is observed, growth/predation rates are computed, populations are updated.
+Consider modeling a **Lotka-Volterra predator-prey system** as a GDS. The state space is (prey_population, predator_population). Each evaluation: the environment is observed, growth/predation rates are computed, populations are updated.
 
 **gds-framework provides** (domain-neutral):
 - `TypeDef(name="Population", python_type=int, constraint=lambda x: x >= 0)` — constrained types

--- a/packages/gds-framework/gds/blocks/base.py
+++ b/packages/gds-framework/gds/blocks/base.py
@@ -60,7 +60,7 @@ class Block(Tagged, ABC):
         )
 
     def feedback(self, wiring: list[Wiring]) -> FeedbackLoop:
-        """Wrap with backward feedback within a single timestep."""
+        """Wrap with backward feedback within a single evaluation."""
         from gds.blocks.composition import FeedbackLoop
 
         return FeedbackLoop(
@@ -70,7 +70,7 @@ class Block(Tagged, ABC):
         )
 
     def loop(self, wiring: list[Wiring], exit_condition: str = "") -> TemporalLoop:
-        """Wrap with forward temporal iteration across timesteps."""
+        """Wrap with structural recurrence across temporal boundaries."""
         from gds.blocks.composition import TemporalLoop
 
         return TemporalLoop(

--- a/packages/gds-framework/gds/blocks/composition.py
+++ b/packages/gds-framework/gds/blocks/composition.py
@@ -4,8 +4,8 @@ These operators combine blocks into larger composite systems:
 
 - **Stack** (``>>``) — chains blocks so one's output feeds another's input.
 - **Parallel** (``|``) — runs blocks side-by-side with no shared wires.
-- **Feedback** — connects backward_out to backward_in within a single timestep.
-- **Temporal Loop** — connects forward_out to forward_in across timesteps.
+- **Feedback** — connects backward_out to backward_in within a single evaluation.
+- **Temporal Loop** — connects forward_out to forward_in across temporal boundaries.
 """
 
 from __future__ import annotations
@@ -103,7 +103,7 @@ class ParallelComposition(Block):
 
 
 class FeedbackLoop(Block):
-    """Backward feedback within a single timestep (backward_out -> backward_in)."""
+    """Backward feedback within a single evaluation (backward_out -> backward_in)."""
 
     inner: Block
     feedback_wiring: list[Wiring]
@@ -118,7 +118,7 @@ class FeedbackLoop(Block):
 
 
 class TemporalLoop(Block):
-    """Forward temporal iteration across timesteps (forward_out -> forward_in).
+    """Structural recurrence across temporal boundaries (forward_out -> forward_in).
 
     All temporal wiring must be covariant direction.
     """

--- a/packages/gds-framework/gds/ir/models.py
+++ b/packages/gds-framework/gds/ir/models.py
@@ -44,8 +44,8 @@ class CompositionType(StrEnum):
 
     - SEQUENTIAL — output of one feeds input of next (stack).
     - PARALLEL — blocks run side-by-side with no shared wires.
-    - FEEDBACK — backward_out→backward_in connections within a timestep.
-    - TEMPORAL — forward_out→forward_in connections across timesteps.
+    - FEEDBACK — backward_out→backward_in connections within an evaluation.
+    - TEMPORAL — forward_out→forward_in connections across temporal boundaries.
     """
 
     SEQUENTIAL = "sequential"
@@ -84,7 +84,7 @@ class WiringIR(BaseModel):
     wiring_type: str = ""
     direction: FlowDirection
     is_feedback: bool = False
-    is_temporal: bool = False
+    is_temporal: bool = False  # Structural recurrence marker — no time model implied
     category: str = "dataflow"
 
 

--- a/packages/gds-framework/gds/state.py
+++ b/packages/gds-framework/gds/state.py
@@ -4,7 +4,7 @@ In GDS terms, the full state space X is the product of all entity states:
     X = Entity_1.state x Entity_2.state x ... x Entity_n.state
 
 Entities correspond to actors, resources, registries — anything that
-persists across timesteps and has mutable state.
+persists across temporal boundaries and has mutable state.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ class Entity(Tagged):
 
     In GDS terms, the full state space X is the product of all entity
     state spaces. Entities correspond to actors, resources, registries —
-    anything that persists across timesteps.
+    anything that persists across temporal boundaries.
     """
 
     name: str

--- a/packages/gds-framework/gds/verification/generic_checks.py
+++ b/packages/gds-framework/gds/verification/generic_checks.py
@@ -281,7 +281,7 @@ def check_g005_sequential_type_compatibility(system: SystemIR) -> list[Finding]:
 
 
 def check_g006_covariant_acyclicity(system: SystemIR) -> list[Finding]:
-    """G-006: Covariant flow graph must be a DAG (no cycles within a timestep).
+    """G-006: Covariant flow graph must be a DAG (no cycles within an evaluation).
 
     Temporal wirings and contravariant wirings are excluded.
     """


### PR DESCRIPTION
## Summary
- Create formal temporal agnosticism design document with invariant statement, proof by inspection of all four composition operators, OGS existence proof, and vocabulary guide
- Add three-layer temporal stack diagram to architecture guide
- Audit and fix temporal language across 32 files (6 Python source, 25 docs, 2 CLAUDE.md files) replacing "timestep" terminology with temporally neutral vocabulary
- DSL-specific docs unchanged — they legitimately declare time models at the DSL layer

## Test plan
- [x] 455 tests pass (docstring/doc changes only, no logic changes)
- [x] Ruff lint + format clean

Addresses #158