### PR TITLE
test: add requirement traceability markers and fill SC-005..SC-009 gaps

### DIFF
--- a/docs/framework/design/traceability-matrix.md
+++ b/docs/framework/design/traceability-matrix.md
@@ -1,0 +1,40 @@
+# Verification Check Traceability Matrix
+
+This document maps formal verification requirements (from [Check Specifications](check-specifications.md))
+to their test implementations.
+
+## Matrix
+
+| Requirement | Test File | Test Class/Method | Coverage |
+|------------|-----------|-------------------|----------|
+| G-001 | test_verification.py | TestG001 | Domain/codomain matching pass/fail |
+| G-002 | test_verification.py | TestG002 | Signature completeness pass/fail |
+| G-003 | test_verification.py | TestG003 | Direction consistency pass/fail |
+| G-004 | test_verification.py | TestG004 | Dangling wirings pass/fail |
+| G-005 | test_verification.py | TestG005 | Sequential type compatibility pass/fail |
+| G-006 | test_verification.py | TestG006 | Covariant acyclicity pass/fail |
+| SC-001 | test_spec_checks.py | TestCompleteness | Orphan variable detection |
+| SC-002 | test_spec_checks.py | TestDeterminism | Write conflict detection |
+| SC-003 | test_spec_checks.py | TestReachability | Signal path queries |
+| SC-004 | test_spec_checks.py | TestTypeSafety | Wire-space consistency |
+| SC-005 | test_spec_checks.py | TestParameterReferences | Parameter resolution pass/fail |
+| SC-006 | test_spec_checks.py | TestCanonicalWellformedness | Non-empty f (mechanism exists) |
+| SC-007 | test_spec_checks.py | TestCanonicalWellformedness | Non-empty X (entity exists) |
+| SC-008 | test_spec_checks.py | TestAdmissibilityReferences | Constraint reference validation |
+| SC-009 | test_spec_checks.py | TestTransitionReads | Transition signature validation |
+
+## Running Requirement-Traced Tests
+
+```bash
+# Run all requirement-traced tests
+uv run --package gds-framework pytest packages/gds-framework/tests -v -m "requirement"
+
+# Run tests for a specific requirement
+uv run --package gds-framework pytest packages/gds-framework/tests -v -m "requirement('G-006')"
+```
+
+## Coverage Gaps
+
+As of this document's creation, all 15 core checks have at least one positive and one negative test case.
+Domain-specific checks (CS-xxx, SF-xxx, T-xxx, S-xxx, etc.) are tested in their respective packages
+but are not yet covered by this traceability matrix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -388,6 +388,7 @@ nav:
       - View Stratification: guides/view-stratification.md
       - Ecosystem: framework/ecosystem.md
       - Semantic Web Integration: research/semantic-web-summary.md
+      - Traceability Matrix: framework/design/traceability-matrix.md
       - Formal Verification:
           - Verification Plan: research/verification-plan.md
           - R3 Non-Representability: research/verification/r3-undecidability.md

--- a/packages/gds-framework/pyproject.toml
+++ b/packages/gds-framework/pyproject.toml
@@ -56,6 +56,9 @@ packages = ["gds"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--import-mode=importlib --cov=gds --cov-report=term-missing --no-header -q"
+markers = [
+    "requirement(id): links test to a formal requirement from check-specifications.md",
+]
 
 [tool.coverage.run]
 source = ["gds"]

--- a/packages/gds-framework/tests/test_spec_checks.py
+++ b/packages/gds-framework/tests/test_spec_checks.py
@@ -4,16 +4,22 @@ import pytest
 
 from gds.blocks.roles import BoundaryAction, ControlAction, Mechanism, Policy
 from gds.canonical import project_canonical
+from gds.constraints import AdmissibleInputConstraint, TransitionSignature
+from gds.parameters import ParameterDef
 from gds.spec import GDSSpec, SpecWiring, Wire
 from gds.state import Entity, StateVariable
 from gds.types.interface import Interface, port
 from gds.types.typedef import TypeDef
 from gds.verification.findings import Severity
 from gds.verification.spec_checks import (
+    check_admissibility_references,
+    check_canonical_wellformedness,
     check_completeness,
     check_controlaction_pathway,
     check_determinism,
+    check_parameter_references,
     check_reachability,
+    check_transition_reads,
     check_type_safety,
 )
 
@@ -36,6 +42,7 @@ def entity_with_var(pop_type):
 # ── SC-001: Completeness ────────────────────────────────────
 
 
+@pytest.mark.requirement("SC-001")
 class TestCompleteness:
     def test_orphan_variable_detected(self, entity_with_var):
         spec = GDSSpec(name="Test")
@@ -68,6 +75,7 @@ class TestCompleteness:
 # ── SC-002: Determinism ──────────────────────────────────────
 
 
+@pytest.mark.requirement("SC-002")
 class TestDeterminism:
     def test_write_conflict_detected(self, entity_with_var):
         spec = GDSSpec(name="Test")
@@ -115,6 +123,7 @@ class TestDeterminism:
 # ── SC-003: Reachability ─────────────────────────────────────
 
 
+@pytest.mark.requirement("SC-003")
 class TestReachability:
     def test_reachable(self):
         spec = GDSSpec(name="Test")
@@ -171,6 +180,7 @@ class TestReachability:
 # ── SC-004: Type safety ──────────────────────────────────────
 
 
+@pytest.mark.requirement("SC-004")
 class TestTypeSafety:
     def test_valid_space_reference(self):
         t = TypeDef(name="Prob", python_type=float)
@@ -231,7 +241,7 @@ class TestTypeSafety:
         assert len(passed) >= 1
 
 
-# ── SC-010: ControlAction pathway ──────────────────────────
+# ── SC-010: ControlAction pathway ───���─────────────────��────
 
 
 class TestControlActionPathway:
@@ -397,3 +407,180 @@ class TestCanonicalOutputPorts:
         spec.register_block(m)
         formula = project_canonical(spec).formula()
         assert "C(x, d)" not in formula
+
+
+# -- SC-005: Parameter References ------------------------------------
+
+
+@pytest.mark.requirement("SC-005")
+class TestParameterReferences:
+    def test_unresolved_param_detected(self):
+        """Block uses a parameter not registered in the spec."""
+        spec = GDSSpec(name="Test")
+        m = Mechanism(
+            name="Mech",
+            interface=Interface(forward_in=(port("X"),)),
+            updates=[("E", "v")],
+            params_used=["alpha"],
+        )
+        spec.register_block(m)
+        findings = check_parameter_references(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) >= 1
+        assert failed[0].check_id == "SC-005"
+        assert failed[0].severity == Severity.ERROR
+
+    def test_resolved_params_pass(self):
+        """All params_used entries resolve to registered parameters."""
+        rate_type = TypeDef(name="Rate", python_type=float)
+        spec = GDSSpec(name="Test")
+        spec.register_type(rate_type)
+        spec.register_parameter(ParameterDef(name="alpha", typedef=rate_type))
+        m = Mechanism(
+            name="Mech",
+            interface=Interface(forward_in=(port("X"),)),
+            updates=[("E", "v")],
+            params_used=["alpha"],
+        )
+        spec.register_block(m)
+        findings = check_parameter_references(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) == 0
+
+    def test_no_params_passes(self):
+        """Spec with no parameter usage passes trivially."""
+        spec = GDSSpec(name="Empty")
+        findings = check_parameter_references(spec)
+        passed = [f for f in findings if f.passed]
+        assert len(passed) >= 1
+
+
+# -- SC-006/SC-007: Canonical Wellformedness --------------------------
+
+
+@pytest.mark.requirement("SC-006")
+@pytest.mark.requirement("SC-007")
+class TestCanonicalWellformedness:
+    def test_no_mechanisms_warns(self):
+        """Spec with no mechanisms should warn that f is empty (SC-006)."""
+        spec = GDSSpec(name="Test")
+        # Add a policy but no mechanism
+        p = Policy(name="P")
+        spec.register_block(p)
+        findings = check_canonical_wellformedness(spec)
+        sc006 = [f for f in findings if f.check_id == "SC-006"]
+        assert len(sc006) == 1
+        assert not sc006[0].passed
+        assert sc006[0].severity == Severity.WARNING
+
+    def test_no_entities_warns(self):
+        """Spec with no entities should warn that X is empty (SC-007)."""
+        spec = GDSSpec(name="Test")
+        m = Mechanism(name="M", updates=[])
+        spec.register_block(m)
+        findings = check_canonical_wellformedness(spec)
+        sc007 = [f for f in findings if f.check_id == "SC-007"]
+        assert len(sc007) == 1
+        assert not sc007[0].passed
+        assert sc007[0].severity == Severity.WARNING
+
+    def test_wellformed_passes(self, entity_with_var):
+        """Spec with both mechanisms and entities passes both checks."""
+        spec = GDSSpec(name="Test")
+        spec.register_entity(entity_with_var)
+        m = Mechanism(name="M", updates=[("Prey", "population")])
+        spec.register_block(m)
+        findings = check_canonical_wellformedness(spec)
+        sc006 = [f for f in findings if f.check_id == "SC-006"]
+        sc007 = [f for f in findings if f.check_id == "SC-007"]
+        assert all(f.passed for f in sc006)
+        assert all(f.passed for f in sc007)
+
+
+# -- SC-008: Admissibility References ---------------------------------
+
+
+@pytest.mark.requirement("SC-008")
+class TestAdmissibilityReferences:
+    def test_nonexistent_boundary_detected(self):
+        """Constraint referencing a missing BoundaryAction raises ERROR."""
+        spec = GDSSpec(name="Test")
+        ac = AdmissibleInputConstraint(
+            name="limit",
+            boundary_block="Ghost",
+            depends_on=[],
+        )
+        spec.register_admissibility(ac)
+        findings = check_admissibility_references(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) >= 1
+        assert failed[0].check_id == "SC-008"
+        assert failed[0].severity == Severity.ERROR
+
+    def test_valid_constraint_passes(self, entity_with_var):
+        """Constraint referencing a registered BoundaryAction passes."""
+        spec = GDSSpec(name="Test")
+        spec.register_entity(entity_with_var)
+        ba = BoundaryAction(
+            name="Sensor",
+            interface=Interface(forward_out=(port("Signal"),)),
+        )
+        spec.register_block(ba)
+        ac = AdmissibleInputConstraint(
+            name="limit",
+            boundary_block="Sensor",
+            depends_on=[("Prey", "population")],
+        )
+        spec.register_admissibility(ac)
+        findings = check_admissibility_references(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) == 0
+
+    def test_no_constraints_passes(self):
+        """Spec with no admissibility constraints passes trivially."""
+        spec = GDSSpec(name="Empty")
+        findings = check_admissibility_references(spec)
+        passed = [f for f in findings if f.passed]
+        assert len(passed) >= 1
+
+
+# -- SC-009: Transition Reads ------------------------------------------
+
+
+@pytest.mark.requirement("SC-009")
+class TestTransitionReads:
+    def test_nonexistent_mechanism_detected(self):
+        """Signature referencing a missing Mechanism raises ERROR."""
+        spec = GDSSpec(name="Test")
+        ts = TransitionSignature(
+            mechanism="Ghost",
+            reads=[],
+        )
+        spec.register_transition_signature(ts)
+        findings = check_transition_reads(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) >= 1
+        assert failed[0].check_id == "SC-009"
+        assert failed[0].severity == Severity.ERROR
+
+    def test_valid_signature_passes(self, entity_with_var):
+        """Signature referencing a registered Mechanism passes."""
+        spec = GDSSpec(name="Test")
+        spec.register_entity(entity_with_var)
+        m = Mechanism(name="Update", updates=[("Prey", "population")])
+        spec.register_block(m)
+        ts = TransitionSignature(
+            mechanism="Update",
+            reads=[("Prey", "population")],
+        )
+        spec.register_transition_signature(ts)
+        findings = check_transition_reads(spec)
+        failed = [f for f in findings if not f.passed]
+        assert len(failed) == 0
+
+    def test_no_signatures_passes(self):
+        """Spec with no transition signatures passes trivially."""
+        spec = GDSSpec(name="Empty")
+        findings = check_transition_reads(spec)
+        passed = [f for f in findings if f.passed]
+        assert len(passed) >= 1

--- a/packages/gds-framework/tests/test_verification.py
+++ b/packages/gds-framework/tests/test_verification.py
@@ -1,5 +1,7 @@
 """Tests for generic verification checks (G-001 through G-006)."""
 
+import pytest
+
 from gds.ir.models import BlockIR, FlowDirection, InputIR, SystemIR, WiringIR
 from gds.verification.engine import verify
 from gds.verification.findings import VerificationReport
@@ -15,6 +17,7 @@ from gds.verification.generic_checks import (
 # ── G-001: Domain/codomain matching ─────────────────────────
 
 
+@pytest.mark.requirement("G-001")
 class TestG001:
     def test_matching_wiring_passes(self, sample_system_ir):
         findings = check_g001_domain_codomain_matching(sample_system_ir)
@@ -65,6 +68,7 @@ class TestG001:
 # ── G-002: Signature completeness ────────────────────────────
 
 
+@pytest.mark.requirement("G-002")
 class TestG002:
     def test_complete_block_passes(self, sample_system_ir):
         findings = check_g002_signature_completeness(sample_system_ir)
@@ -137,6 +141,7 @@ class TestG002:
 # ── G-003: Direction consistency ─────────────────────────────
 
 
+@pytest.mark.requirement("G-003")
 class TestG003:
     def test_covariant_wiring_no_findings(self, sample_system_ir):
         """Covariant wirings are handled by G-001 — G-003 skips them."""
@@ -228,6 +233,7 @@ class TestG003:
 # ── G-004: Dangling wirings ──────────────────────────────────
 
 
+@pytest.mark.requirement("G-004")
 class TestG004:
     def test_valid_passes(self, sample_system_ir):
         findings = check_g004_dangling_wirings(sample_system_ir)
@@ -291,6 +297,7 @@ class TestG004:
 # ── G-005: Sequential type compatibility ─────────────────────
 
 
+@pytest.mark.requirement("G-005")
 class TestG005:
     def test_compatible_passes(self, sample_system_ir):
         findings = check_g005_sequential_type_compatibility(sample_system_ir)
@@ -343,6 +350,7 @@ class TestG005:
 # ── G-006: Covariant acyclicity ──────────────────────────────
 
 
+@pytest.mark.requirement("G-006")
 class TestG006:
     def test_dag_passes(self, sample_system_ir):
         findings = check_g006_covariant_acyclicity(sample_system_ir)


### PR DESCRIPTION
## Summary
- Register custom `requirement(id)` pytest marker for formal requirement tracing
- Annotate all existing verification tests (G-001..G-006, SC-001..SC-004) with markers
- Add 12 new tests filling coverage gaps for SC-005 (parameter references), SC-006/SC-007 (canonical wellformedness), SC-008 (admissibility references), SC-009 (transition reads)
- Create traceability matrix document mapping all 15 requirements to test implementations

## Test plan
- [x] 467 tests pass (+12 new tests)
- [x] 46 tests selected by `-m "requirement"` marker filter
- [x] Ruff lint + format clean

Closes #156