### PR TITLE
fix(gds-analysis): guard gds-continuous import in backward_reachability

### DIFF
--- a/packages/gds-analysis/gds_analysis/backward_reachability.py
+++ b/packages/gds-analysis/gds_analysis/backward_reachability.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from gds_continuous import ODEModel, ODESimulation
-
 if TYPE_CHECKING:
+    from gds_continuous import ODEModel, ODESimulation
     from gds_continuous.types import ODEFunction
 
 
@@ -109,6 +108,14 @@ def backward_reachable_set(
     -------
     BackwardReachableSet with trajectories and metadata.
     """
+    try:
+        from gds_continuous import ODEModel, ODESimulation
+    except ImportError as exc:
+        raise ImportError(
+            "backward_reachable_set requires gds-continuous. "
+            "Install it with: pip install gds-analysis[continuous]"
+        ) from exc
+
     params = params or {}
 
     def backward_rhs(t: float, y: list[float], p: dict[str, Any]) -> list[float]:


### PR DESCRIPTION
## Summary
- Move `ODEModel`/`ODESimulation` import behind `TYPE_CHECKING` guard and add lazy import with clear error message at call time
- This was the only module missing an optional-dependency guard — all other packages already handle their optional imports correctly

## Test plan
- [x] `gds-analysis` importable without `gds-continuous` installed
- [x] Clear error message when `backward_reachable_set()` is called without `gds-continuous`