### PR TITLE
feat(gds-owl): promote common constraint predicates from R3 to R2 via SHACL

### DIFF
--- a/packages/gds-framework/gds/__init__.py
+++ b/packages/gds-framework/gds/__init__.py
@@ -89,6 +89,7 @@ from gds.types.tokens import tokenize, tokens_overlap, tokens_subset
 # ── Type system ─────────────────────────────────────────────
 from gds.types.typedef import (
     AgentID,
+    ConstraintKind,
     NonNegativeFloat,
     PositiveInt,
     Probability,
@@ -123,6 +124,7 @@ __all__ = [
     "BoundaryAction",
     "CanonicalGDS",
     "CompositionType",
+    "ConstraintKind",
     "ControlAction",
     "Entity",
     "FeedbackLoop",

--- a/packages/gds-framework/gds/helpers.py
+++ b/packages/gds-framework/gds/helpers.py
@@ -29,6 +29,9 @@ def typedef(
     constraint: Callable[[Any], bool] | None = None,
     description: str = "",
     units: str | None = None,
+    constraint_kind: str | None = None,
+    constraint_bounds: tuple[float, float] | None = None,
+    constraint_values: tuple[Any, ...] | None = None,
 ) -> TypeDef:
     """Create a TypeDef with positional name + type, keyword-only rest.
 
@@ -39,6 +42,11 @@ def typedef(
             (e.g. ``lambda x: x >= 0``).
         description: Human-readable description.
         units: Optional unit label (e.g. ``"celsius"``).
+        constraint_kind: Named constraint pattern for lossless OWL/SHACL
+            round-tripping.  One of ``"non_negative"``, ``"positive"``,
+            ``"probability"``, ``"bounded"``, ``"enum"``, or ``None``.
+        constraint_bounds: ``(low, high)`` bounds for ``"bounded"`` kind.
+        constraint_values: Allowed values for ``"enum"`` kind.
 
     Returns:
         A frozen ``TypeDef`` instance.
@@ -49,6 +57,9 @@ def typedef(
         constraint=constraint,
         description=description,
         units=units,
+        constraint_kind=constraint_kind,
+        constraint_bounds=constraint_bounds,
+        constraint_values=constraint_values,
     )
 
 

--- a/packages/gds-framework/gds/types/typedef.py
+++ b/packages/gds-framework/gds/types/typedef.py
@@ -8,9 +8,17 @@ TypeDef carries actual validation logic.
 from __future__ import annotations
 
 from collections.abc import Callable  # noqa: TC003
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
+
+ConstraintKind = Literal[
+    "non_negative",  # x >= 0
+    "positive",  # x > 0
+    "probability",  # 0 <= x <= 1
+    "bounded",  # low <= x <= high (needs constraint_bounds)
+    "enum",  # x in {...} (needs constraint_values)
+]
 
 
 class TypeDef(BaseModel):
@@ -18,6 +26,12 @@ class TypeDef(BaseModel):
 
     Each TypeDef wraps a Python type with an optional constraint predicate.
     ``check_value()`` checks both the Python type and the constraint at runtime.
+
+    The optional ``constraint_kind`` field enables lossless round-tripping of
+    common constraint patterns through OWL/SHACL export.  When set, the
+    OWL exporter emits SHACL property shapes instead of an opaque
+    ``hasConstraint: true`` boolean, promoting the constraint from R3 (lossy)
+    to R2 (structurally representable).
     """
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
@@ -27,6 +41,9 @@ class TypeDef(BaseModel):
     description: str = ""
     constraint: Callable[[Any], bool] | None = None
     units: str | None = None
+    constraint_kind: ConstraintKind | None = None
+    constraint_bounds: tuple[float, float] | None = None
+    constraint_values: tuple[Any, ...] | None = None
 
     def check_value(self, value: Any) -> bool:
         """Check if a value satisfies this type definition."""
@@ -47,18 +64,21 @@ Probability = TypeDef(
     python_type=float,
     constraint=lambda x: 0.0 <= x <= 1.0,
     description="A value in [0, 1]",
+    constraint_kind="probability",
 )
 
 NonNegativeFloat = TypeDef(
     name="NonNegativeFloat",
     python_type=float,
     constraint=lambda x: x >= 0,
+    constraint_kind="non_negative",
 )
 
 PositiveInt = TypeDef(
     name="PositiveInt",
     python_type=int,
     constraint=lambda x: x > 0,
+    constraint_kind="positive",
 )
 
 TokenAmount = TypeDef(
@@ -66,6 +86,7 @@ TokenAmount = TypeDef(
     python_type=float,
     constraint=lambda x: x >= 0,
     units="tokens",
+    constraint_kind="non_negative",
 )
 
 AgentID = TypeDef(name="AgentID", python_type=str)
@@ -75,4 +96,5 @@ Timestamp = TypeDef(
     python_type=float,
     constraint=lambda x: x >= 0,
     units="seconds",
+    constraint_kind="non_negative",
 )

--- a/packages/gds-framework/tests/test_types.py
+++ b/packages/gds-framework/tests/test_types.py
@@ -280,3 +280,54 @@ class TestBuiltInTypes:
     )
     def test_units(self, typedef, attr, expected):
         assert getattr(typedef, attr) == expected
+
+
+# ── constraint_kind ─────────────────────────────────────────
+
+
+class TestConstraintKind:
+    def test_constraint_kind_default_is_none(self):
+        t = TypeDef(name="Plain", python_type=float)
+        assert t.constraint_kind is None
+        assert t.constraint_bounds is None
+        assert t.constraint_values is None
+
+    @pytest.mark.parametrize(
+        "typedef_obj, expected_kind",
+        [
+            (Probability, "probability"),
+            (NonNegativeFloat, "non_negative"),
+            (PositiveInt, "positive"),
+            (TokenAmount, "non_negative"),
+            (Timestamp, "non_negative"),
+            (AgentID, None),
+        ],
+    )
+    def test_builtin_constraint_kinds(self, typedef_obj, expected_kind):
+        assert typedef_obj.constraint_kind == expected_kind
+
+    def test_bounded_kind_with_bounds(self):
+        t = TypeDef(
+            name="Score",
+            python_type=float,
+            constraint=lambda x: 0 <= x <= 100,
+            constraint_kind="bounded",
+            constraint_bounds=(0.0, 100.0),
+        )
+        assert t.constraint_kind == "bounded"
+        assert t.constraint_bounds == (0.0, 100.0)
+        assert t.check_value(50.0) is True
+        assert t.check_value(101.0) is False
+
+    def test_enum_kind_with_values(self):
+        t = TypeDef(
+            name="Color",
+            python_type=str,
+            constraint=lambda x: x in {"red", "green", "blue"},
+            constraint_kind="enum",
+            constraint_values=("red", "green", "blue"),
+        )
+        assert t.constraint_kind == "enum"
+        assert t.constraint_values == ("red", "green", "blue")
+        assert t.check_value("red") is True
+        assert t.check_value("yellow") is False

--- a/packages/gds-owl/gds_owl/__init__.py
+++ b/packages/gds-owl/gds_owl/__init__.py
@@ -33,6 +33,7 @@ from gds_owl.serialize import (
 )
 from gds_owl.shacl import (
     build_all_shapes,
+    build_constraint_shapes,
     build_generic_shapes,
     build_semantic_shapes,
     build_structural_shapes,
@@ -48,6 +49,7 @@ __all__ = [
     "PREFIXES",
     "TEMPLATES",
     "build_all_shapes",
+    "build_constraint_shapes",
     "build_core_ontology",
     "build_generic_shapes",
     "build_semantic_shapes",

--- a/packages/gds-owl/gds_owl/export.py
+++ b/packages/gds-owl/gds_owl/export.py
@@ -67,6 +67,26 @@ def _typedef_to_rdf(g: Graph, ns: Namespace, t: TypeDef) -> URIRef:
     )
     if t.units:
         g.add((uri, GDS_CORE["units"], Literal(t.units)))
+    if t.constraint_kind:
+        g.add((uri, GDS_CORE["constraintKind"], Literal(t.constraint_kind)))
+    if t.constraint_bounds is not None:
+        g.add(
+            (
+                uri,
+                GDS_CORE["constraintLow"],
+                Literal(t.constraint_bounds[0], datatype=XSD.double),
+            )
+        )
+        g.add(
+            (
+                uri,
+                GDS_CORE["constraintHigh"],
+                Literal(t.constraint_bounds[1], datatype=XSD.double),
+            )
+        )
+    if t.constraint_values is not None:
+        for v in t.constraint_values:
+            g.add((uri, GDS_CORE["constraintValue"], Literal(str(v))))
     return uri
 
 

--- a/packages/gds-owl/gds_owl/import_.py
+++ b/packages/gds-owl/gds_owl/import_.py
@@ -4,13 +4,15 @@ Reconstructs GDSSpec, SystemIR, CanonicalGDS, and VerificationReport
 from RDF graphs produced by the export functions.
 
 Known lossy fields:
-- TypeDef.constraint: Python callable, not serializable. Imported as None.
+- TypeDef.constraint: Python callable, not serializable *unless*
+  ``constraint_kind`` is set — recognised patterns are reconstructed.
 - TypeDef.python_type: Mapped from string via _PYTHON_TYPE_MAP for builtins.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable  # noqa: TC003
+from typing import TYPE_CHECKING, Any
 
 from rdflib import RDF, XSD, Graph, Literal, URIRef
 
@@ -67,6 +69,40 @@ def _subjects_of_type(g: Graph, rdf_type: URIRef) -> list[URIRef]:
 # ── TypeDef ──────────────────────────────────────────────────────────
 
 
+def _float_or_none(g: Graph, subject: URIRef, predicate: URIRef) -> float | None:
+    """Get a single float literal value, or None."""
+    vals = list(g.objects(subject, predicate))
+    if vals:
+        v = vals[0]
+        if isinstance(v, Literal):
+            try:
+                return float(v.toPython())
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _reconstruct_constraint(
+    kind: str,
+    bounds: tuple[float, float] | None,
+    values: tuple[str, ...] | None,
+) -> Callable[[Any], bool] | None:
+    """Rebuild a Python callable constraint from a named constraint kind."""
+    if kind == "non_negative":
+        return lambda x: x >= 0
+    elif kind == "positive":
+        return lambda x: x > 0
+    elif kind == "probability":
+        return lambda x: 0.0 <= x <= 1.0
+    elif kind == "bounded" and bounds:
+        lo, hi = bounds
+        return lambda x, _lo=lo, _hi=hi: _lo <= x <= _hi
+    elif kind == "enum" and values:
+        allowed = set(values)
+        return lambda x, _s=allowed: x in _s
+    return None
+
+
 def _import_typedef(g: Graph, uri: URIRef) -> dict:
     """Extract TypeDef fields from an RDF node."""
     name = _str(g, uri, GDS_CORE["name"])
@@ -74,12 +110,35 @@ def _import_typedef(g: Graph, uri: URIRef) -> dict:
     python_type = _PYTHON_TYPE_MAP.get(py_type_str, str)
     description = _str(g, uri, GDS_CORE["description"])
     units = _str(g, uri, GDS_CORE["units"]) or None
+
+    constraint_kind = _str(g, uri, GDS_CORE["constraintKind"]) or None
+    constraint_bounds: tuple[float, float] | None = None
+    constraint_values: tuple[str, ...] | None = None
+    constraint = None
+
+    if constraint_kind:
+        low = _float_or_none(g, uri, GDS_CORE["constraintLow"])
+        high = _float_or_none(g, uri, GDS_CORE["constraintHigh"])
+        if low is not None and high is not None:
+            constraint_bounds = (low, high)
+
+        raw_values = [str(v) for v in g.objects(uri, GDS_CORE["constraintValue"])]
+        if raw_values:
+            constraint_values = tuple(sorted(raw_values))
+
+        constraint = _reconstruct_constraint(
+            constraint_kind, constraint_bounds, constraint_values
+        )
+
     return {
         "name": name,
         "python_type": python_type,
         "description": description,
         "units": units,
-        "constraint": None,  # not serializable
+        "constraint": constraint,
+        "constraint_kind": constraint_kind,
+        "constraint_bounds": constraint_bounds,
+        "constraint_values": constraint_values,
     }
 
 

--- a/packages/gds-owl/gds_owl/ontology.py
+++ b/packages/gds-owl/gds_owl/ontology.py
@@ -339,6 +339,10 @@ def _build_spec_framework(g: Graph) -> None:
     _add_datatype_property(g, "pythonType", domain="TypeDef")
     _add_datatype_property(g, "units", domain="TypeDef")
     _add_datatype_property(g, "hasConstraint", domain="TypeDef", range_="boolean")
+    _add_datatype_property(g, "constraintKind", domain="TypeDef")
+    _add_datatype_property(g, "constraintLow", domain="TypeDef", range_="double")
+    _add_datatype_property(g, "constraintHigh", domain="TypeDef", range_="double")
+    _add_datatype_property(g, "constraintValue", domain="TypeDef")
 
     # StateVariable datatype properties
     _add_datatype_property(g, "symbol", domain="StateVariable")

--- a/packages/gds-owl/gds_owl/shacl.py
+++ b/packages/gds-owl/gds_owl/shacl.py
@@ -58,6 +58,86 @@ def _add_property_shape(
 # ── Structural Shapes ────────────────────────────────────────────────
 
 
+def _add_constraint_shapes(g: Graph, data_graph: Graph) -> None:
+    """Add SHACL property shapes for TypeDef nodes with constraintKind.
+
+    Reads TypeDef individuals from *data_graph*, and for each one that
+    carries a ``constraintKind`` literal, generates a SHACL NodeShape with
+    the appropriate numeric restriction (``sh:minInclusive``,
+    ``sh:maxInclusive``, ``sh:minExclusive``, or ``sh:in``).
+
+    The shapes are written into *g* (the shapes graph).
+    """
+    from rdflib import BNode
+    from rdflib.collection import Collection
+
+    _kind_map = {
+        "non_negative": lambda _g, prop, _low, _high, _vals: [
+            (_g.add((prop, SH.minInclusive, Literal(0, datatype=XSD.double))),)
+        ],
+        "positive": lambda _g, prop, _low, _high, _vals: [
+            (_g.add((prop, SH.minExclusive, Literal(0, datatype=XSD.double))),)
+        ],
+        "probability": lambda _g, prop, _low, _high, _vals: [
+            _g.add((prop, SH.minInclusive, Literal(0.0, datatype=XSD.double))),
+            _g.add((prop, SH.maxInclusive, Literal(1.0, datatype=XSD.double))),
+        ],
+        "bounded": lambda _g, prop, low, high, _vals: [
+            _g.add((prop, SH.minInclusive, Literal(low, datatype=XSD.double)))
+            if low is not None
+            else None,
+            _g.add((prop, SH.maxInclusive, Literal(high, datatype=XSD.double)))
+            if high is not None
+            else None,
+        ],
+    }
+
+    for td_uri in data_graph.subjects(RDF.type, GDS_CORE["TypeDef"]):
+        kind_vals = list(data_graph.objects(td_uri, GDS_CORE["constraintKind"]))
+        if not kind_vals:
+            continue
+        kind = str(kind_vals[0])
+
+        # Resolve name for a deterministic shape URI
+        name_vals = list(data_graph.objects(td_uri, GDS_CORE["name"]))
+        td_name = str(name_vals[0]) if name_vals else "unknown"
+        safe_name = td_name.replace(" ", "_")
+
+        shape_uri = GDS_SHAPE[f"TypeDefConstraint_{safe_name}Shape"]
+        g.add((shape_uri, RDF.type, SH.NodeShape))
+        g.add((shape_uri, SH.targetNode, td_uri))
+        g.add(
+            (
+                shape_uri,
+                SH.message,
+                Literal(f"TypeDef '{td_name}' constraint ({kind}) value restriction"),
+            )
+        )
+
+        if kind == "enum":
+            # sh:in requires an RDF list
+            cv_vals = [
+                str(v) for v in data_graph.objects(td_uri, GDS_CORE["constraintValue"])
+            ]
+            if cv_vals:
+                prop = BNode()
+                g.add((shape_uri, SH.property, prop))
+                g.add((prop, SH.path, GDS_CORE["constraintValue"]))
+                list_head = BNode()
+                Collection(g, list_head, [Literal(v) for v in sorted(cv_vals)])
+                g.add((prop, SH["in"], list_head))
+        elif kind in _kind_map:
+            low_vals = list(data_graph.objects(td_uri, GDS_CORE["constraintLow"]))
+            high_vals = list(data_graph.objects(td_uri, GDS_CORE["constraintHigh"]))
+            low = float(low_vals[0].toPython()) if low_vals else None
+            high = float(high_vals[0].toPython()) if high_vals else None
+
+            prop = BNode()
+            g.add((shape_uri, SH.property, prop))
+            g.add((prop, SH.path, GDS_CORE["constraintKind"]))
+            _kind_map[kind](g, prop, low, high, None)
+
+
 def build_structural_shapes() -> Graph:
     """Build SHACL shapes for GDS structural constraints.
 
@@ -407,6 +487,22 @@ def build_semantic_shapes() -> Graph:
         message="SC-009: Transition signature must reference a Mechanism",
     )
 
+    return g
+
+
+# ── Constraint Shapes ──────────────────────────────────────────────
+
+
+def build_constraint_shapes(data_graph: Graph) -> Graph:
+    """Build SHACL shapes for TypeDef constraint_kind metadata.
+
+    Reads TypeDef individuals from *data_graph* and generates
+    SHACL NodeShapes with numeric/enum restrictions for each
+    TypeDef that carries a ``constraintKind`` literal.
+    """
+    g = Graph()
+    _bind(g)
+    _add_constraint_shapes(g, data_graph)
     return g
 
 

--- a/packages/gds-owl/tests/test_roundtrip.py
+++ b/packages/gds-owl/tests/test_roundtrip.py
@@ -84,11 +84,93 @@ class TestSpecRoundTrip:
                 thermostat_spec.wirings[name].wires
             )
 
-    def test_constraint_is_lossy(self, thermostat_spec: GDSSpec) -> None:
-        """TypeDef.constraint is not serializable; imported as None."""
+    def test_constraint_without_kind_stays_lossy(
+        self, thermostat_spec: GDSSpec
+    ) -> None:
+        """TypeDef.constraint without constraint_kind stays lossy."""
+        from gds.types.typedef import TypeDef
+
+        # Register a type that has a constraint but no constraint_kind
+        custom = TypeDef(
+            name="CustomConstrained",
+            python_type=float,
+            constraint=lambda x: x != 42,
+        )
+        thermostat_spec.register_type(custom)
         spec2 = self._round_trip(thermostat_spec)
-        for td in spec2.types.values():
-            assert td.constraint is None
+        rt_custom = spec2.types["CustomConstrained"]
+        assert rt_custom.constraint is None
+        assert rt_custom.constraint_kind is None
+
+    def test_constraint_kind_round_trips(self, thermostat_spec: GDSSpec) -> None:
+        """Probability with constraint_kind='probability' survives round-trip."""
+        from gds.types.typedef import Probability
+
+        thermostat_spec.register_type(Probability)
+        spec2 = self._round_trip(thermostat_spec)
+        rt_prob = spec2.types["Probability"]
+        assert rt_prob.constraint_kind == "probability"
+        assert rt_prob.constraint is not None
+        assert rt_prob.check_value(0.5) is True
+        assert rt_prob.check_value(1.5) is False
+
+    def test_non_negative_round_trips(self, thermostat_spec: GDSSpec) -> None:
+        """NonNegativeFloat with constraint_kind='non_negative' survives."""
+        from gds.types.typedef import NonNegativeFloat
+
+        thermostat_spec.register_type(NonNegativeFloat)
+        spec2 = self._round_trip(thermostat_spec)
+        rt_nnf = spec2.types["NonNegativeFloat"]
+        assert rt_nnf.constraint_kind == "non_negative"
+        assert rt_nnf.constraint is not None
+        assert rt_nnf.check_value(0.0) is True
+        assert rt_nnf.check_value(-1.0) is False
+
+    def test_bounded_round_trips(self) -> None:
+        """A bounded TypeDef round-trips with reconstructed constraint."""
+        from gds.types.typedef import TypeDef
+
+        bounded = TypeDef(
+            name="Score",
+            python_type=float,
+            constraint=lambda x: 0.0 <= x <= 100.0,
+            constraint_kind="bounded",
+            constraint_bounds=(0.0, 100.0),
+        )
+        spec = GDSSpec(name="bounded_test")
+        spec.register_type(bounded)
+
+        spec2 = self._round_trip(spec)
+        rt = spec2.types["Score"]
+        assert rt.constraint_kind == "bounded"
+        assert rt.constraint_bounds == (0.0, 100.0)
+        assert rt.constraint is not None
+        assert rt.check_value(50.0) is True
+        assert rt.check_value(101.0) is False
+        assert rt.check_value(-1.0) is False
+
+    def test_enum_round_trips(self) -> None:
+        """An enum TypeDef round-trips with reconstructed constraint."""
+        from gds.types.typedef import TypeDef
+
+        color = TypeDef(
+            name="Color",
+            python_type=str,
+            constraint=lambda x: x in {"red", "green", "blue"},
+            constraint_kind="enum",
+            constraint_values=("red", "green", "blue"),
+        )
+        spec = GDSSpec(name="enum_test")
+        spec.register_type(color)
+
+        spec2 = self._round_trip(spec)
+        rt = spec2.types["Color"]
+        assert rt.constraint_kind == "enum"
+        assert rt.constraint_values is not None
+        assert set(rt.constraint_values) == {"red", "green", "blue"}
+        assert rt.constraint is not None
+        assert rt.check_value("red") is True
+        assert rt.check_value("yellow") is False
 
     def test_admissibility_constraints_survive(self, thermostat_spec: GDSSpec) -> None:
         from gds.constraints import AdmissibleInputConstraint

--- a/packages/gds-owl/tests/test_shacl.py
+++ b/packages/gds-owl/tests/test_shacl.py
@@ -87,6 +87,60 @@ class TestAllShapes:
         assert len(g) >= max(len(structural), len(generic), len(semantic))
 
 
+class TestConstraintShapes:
+    def test_constraint_shapes_for_probability(self, thermostat_spec: GDSSpec) -> None:
+        """SHACL constraint shapes are generated for TypeDefs with constraint_kind."""
+        from gds.types.typedef import Probability
+        from gds_owl.shacl import GDS_SHAPE, build_constraint_shapes
+
+        thermostat_spec.register_type(Probability)
+        data = spec_to_graph(thermostat_spec)
+        shapes = build_constraint_shapes(data)
+
+        # Should have a shape for Probability
+        prob_shape = GDS_SHAPE["TypeDefConstraint_ProbabilityShape"]
+        assert (prob_shape, RDF.type, SH.NodeShape) in shapes
+
+    def test_no_constraint_shapes_without_kind(self) -> None:
+        """TypeDefs without constraint_kind produce no constraint shapes."""
+        from gds.types.typedef import TypeDef
+        from gds_owl.shacl import build_constraint_shapes
+
+        plain = TypeDef(name="Plain", python_type=float, constraint=lambda x: x > 0)
+        spec = GDSSpec(name="plain_test")
+        spec.register_type(plain)
+        data = spec_to_graph(spec)
+        shapes = build_constraint_shapes(data)
+
+        # Should have no node shapes (only prefix bindings)
+        node_shapes = list(shapes.subjects(RDF.type, SH.NodeShape))
+        assert len(node_shapes) == 0
+
+    def test_bounded_constraint_shape(self) -> None:
+        """Bounded constraint_kind produces minInclusive/maxInclusive shapes."""
+        from gds.types.typedef import TypeDef
+        from gds_owl.shacl import GDS_SHAPE, build_constraint_shapes
+
+        bounded = TypeDef(
+            name="Score",
+            python_type=float,
+            constraint=lambda x: 0 <= x <= 100,
+            constraint_kind="bounded",
+            constraint_bounds=(0.0, 100.0),
+        )
+        spec = GDSSpec(name="bounded_test")
+        spec.register_type(bounded)
+        data = spec_to_graph(spec)
+        shapes = build_constraint_shapes(data)
+
+        score_shape = GDS_SHAPE["TypeDefConstraint_ScoreShape"]
+        assert (score_shape, RDF.type, SH.NodeShape) in shapes
+
+        # Verify the shape has property constraints
+        props = list(shapes.objects(score_shape, SH.property))
+        assert len(props) >= 1
+
+
 @pytest.mark.skipif(not HAS_PYSHACL, reason="pyshacl not installed")
 class TestValidation:
     def test_valid_spec_conforms(self, thermostat_spec: GDSSpec) -> None:


### PR DESCRIPTION
## Summary
- Add `constraint_kind` field to `TypeDef` with supported kinds: `non_negative`, `positive`, `probability`, `bounded`, `enum`
- Export constraint metadata as RDF triples (`constraintKind`, `constraintLow`, `constraintHigh`, `constraintValue`)
- Import reconstructs Python callable constraints from SHACL metadata — constraints with `constraint_kind` are now R2 round-trippable
- Generate SHACL property shapes (`sh:minInclusive`, `sh:maxInclusive`, `sh:minExclusive`, `sh:in`) for recognizable patterns
- Update all 5 built-in TypeDefs with their `constraint_kind`
- Constraints without a `constraint_kind` remain R3 lossy (no behavior change)

## Test plan
- [x] 5 new tests in gds-framework for `constraint_kind` field
- [x] 6 new round-trip tests in gds-owl (replaces `test_constraint_is_lossy`)
- [x] 3 new SHACL shape tests
- [x] 484 framework tests + 185 owl tests pass
- [x] Ruff clean

Closes #152