### PR TITLE
feat(gds-psuu): connect parameter sweep to declared Θ with validation

### DIFF
--- a/docs/psuu/guide/spaces.md
+++ b/docs/psuu/guide/spaces.md
@@ -100,3 +100,86 @@ For the example above: `5 * 113 * 2 = 1130` points.
 | Property | Returns | Description |
 |----------|---------|-------------|
 | `dimension_names` | `list[str]` | Ordered list of parameter names |
+
+---
+
+## Connecting to GDS Parameter Schema
+
+When your system has a `GDSSpec` with a `ParameterSchema` (the declared parameter space, theta), you can connect it to the sweep so that the optimizer never silently explores values outside declared bounds or type constraints.
+
+### Creating a ParameterSpace from a Schema
+
+`ParameterSpace.from_parameter_schema()` automatically creates dimensions from the declared `ParameterDef` entries:
+
+- `float` with bounds becomes `Continuous`
+- `int` with bounds becomes `Integer`
+- Parameters without bounds raise `ValueError` (bounds are required for sweep)
+- Unsupported types raise `TypeError`
+
+```python
+from gds import GDSSpec, typedef, ParameterDef
+from gds_psuu import ParameterSpace
+
+spec = GDSSpec(name="my_system")
+rate_type = typedef("Rate", float, constraint=lambda x: 0.0 <= x <= 1.0)
+spec.register_parameter(ParameterDef(name="growth_rate", typedef=rate_type, bounds=(0.01, 0.5)))
+
+space = ParameterSpace.from_parameter_schema(spec.parameter_schema)
+# space.params == {"growth_rate": Continuous(min_val=0.01, max_val=0.5)}
+```
+
+### Validating an Existing Space
+
+If you build your `ParameterSpace` manually, you can validate it against the schema:
+
+```python
+from gds_psuu import Continuous, ParameterSpace
+
+space = ParameterSpace(params={
+    "growth_rate": Continuous(min_val=-1.0, max_val=2.0),  # exceeds bounds
+})
+
+violations = space.validate_against_schema(spec.parameter_schema)
+for v in violations:
+    print(f"[{v.violation_type}] {v.param}: {v.message}")
+```
+
+Violation types:
+
+| Type | Meaning |
+|------|---------|
+| `missing_from_schema` | Parameter is swept but not declared in the schema |
+| `out_of_bounds` | Sweep range exceeds declared bounds or fails typedef constraint |
+| `type_mismatch` | Dimension type does not match declared Python type |
+
+### PSUU-001 Check
+
+The `check_parameter_space_compatibility()` function wraps validation into the GDS `Finding` pattern:
+
+```python
+from gds_psuu import check_parameter_space_compatibility
+
+findings = check_parameter_space_compatibility(space, spec.parameter_schema)
+for f in findings:
+    print(f"[{f.check_id}] {f.severity}: {f.message}")
+```
+
+### Sweep Integration
+
+Pass `parameter_schema` to `Sweep` for automatic validation before the optimizer loop starts. If any `ERROR`-level violations are found, `run()` raises `ValueError`:
+
+```python
+from gds_psuu import Sweep
+
+sweep = Sweep(
+    model=sim_model,
+    space=space,
+    kpis=kpis,
+    optimizer=optimizer,
+    parameter_schema=spec.parameter_schema,  # optional validation
+)
+sweep.run()  # raises ValueError if space violates schema
+```
+
+!!! note
+    The `parameter_schema` field is optional. If omitted, no validation is performed and the sweep runs as before. Install `gds-framework` (or use the `validation` extra: `pip install gds-psuu[validation]`) to use these features.

--- a/packages/gds-psuu/gds_psuu/__init__.py
+++ b/packages/gds-psuu/gds_psuu/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "0.2.0"
 
+from gds_psuu.checks import check_parameter_space_compatibility
 from gds_psuu.errors import PsuuError, PsuuSearchError, PsuuValidationError
 from gds_psuu.evaluation import EvaluationResult, Evaluator
 from gds_psuu.kpi import KPI, final_state_mean, final_state_std, time_average
@@ -38,6 +39,7 @@ from gds_psuu.space import (
     Integer,
     LinearConstraint,
     ParameterSpace,
+    SchemaViolation,
 )
 from gds_psuu.sweep import Sweep
 from gds_psuu.types import AggregationFn, KPIFn, KPIScores, MetricFn, ParamPoint
@@ -72,11 +74,13 @@ __all__ = [
     "PsuuSearchError",
     "PsuuValidationError",
     "RandomSearchOptimizer",
+    "SchemaViolation",
     "SensitivityResult",
     "SingleKPI",
     "Sweep",
     "SweepResults",
     "WeightedSum",
+    "check_parameter_space_compatibility",
     "final_state_mean",
     "final_state_std",
     "final_value",

--- a/packages/gds-psuu/gds_psuu/checks.py
+++ b/packages/gds-psuu/gds_psuu/checks.py
@@ -1,0 +1,62 @@
+"""PSUU verification checks following the GDS Finding pattern.
+
+Requires ``gds-framework`` to be installed.  All gds-framework imports
+are deferred to function bodies so that importing this module never
+fails when gds-framework is absent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gds.parameters import ParameterSchema
+    from gds.verification.findings import Finding
+
+    from gds_psuu.space import ParameterSpace
+
+
+def check_parameter_space_compatibility(
+    space: ParameterSpace, schema: ParameterSchema
+) -> list[Finding]:
+    """PSUU-001: Swept parameter space is compatible with declared theta.
+
+    Verifies that all swept parameters exist in the schema and that
+    sweep bounds respect declared TypeDef constraints and ParameterDef
+    bounds.
+
+    Returns a list of :class:`~gds.verification.findings.Finding`.
+    """
+    from gds.verification.findings import Finding, Severity
+
+    violations = space.validate_against_schema(schema)
+    findings: list[Finding] = []
+
+    for v in violations:
+        severity = (
+            Severity.WARNING
+            if v.violation_type == "missing_from_schema"
+            else Severity.ERROR
+        )
+        findings.append(
+            Finding(
+                check_id="PSUU-001",
+                severity=severity,
+                message=v.message,
+                source_elements=[v.param],
+                passed=False,
+            )
+        )
+
+    if not findings:
+        findings.append(
+            Finding(
+                check_id="PSUU-001",
+                severity=Severity.INFO,
+                message="Parameter space is compatible with declared schema.",
+                source_elements=list(space.params.keys()),
+                passed=True,
+            )
+        )
+
+    return findings

--- a/packages/gds-psuu/gds_psuu/space.py
+++ b/packages/gds-psuu/gds_psuu/space.py
@@ -6,12 +6,16 @@ import itertools
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable  # noqa: TC003
-from typing import Any, Self
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from gds_psuu.errors import PsuuValidationError
 from gds_psuu.types import ParamPoint  # noqa: TC001
+
+if TYPE_CHECKING:
+    from gds.parameters import ParameterSchema
 
 
 class Continuous(BaseModel):
@@ -65,6 +69,15 @@ class Discrete(BaseModel):
 
 
 Dimension = Continuous | Integer | Discrete
+
+
+@dataclass(frozen=True)
+class SchemaViolation:
+    """A single incompatibility between a sweep dimension and declared schema."""
+
+    param: str
+    violation_type: str  # "missing_from_schema", "out_of_bounds", "type_mismatch"
+    message: str
 
 
 class Constraint(BaseModel, ABC):
@@ -169,3 +182,161 @@ class ParameterSpace(BaseModel):
         if self.constraints:
             return [p for p in all_points if self.is_feasible(p)]
         return all_points
+
+    @classmethod
+    def from_parameter_schema(cls, schema: ParameterSchema) -> ParameterSpace:
+        """Create a ParameterSpace from a GDS ParameterSchema.
+
+        Maps ParameterDef entries to Dimensions:
+
+        - ``float`` with bounds -> ``Continuous``
+        - ``int`` with bounds -> ``Integer``
+        - No bounds -> raises ``ValueError`` (bounds required for sweep)
+        - Unsupported type -> raises ``TypeError``
+
+        Requires ``gds-framework`` to be installed.
+        """
+        from gds.parameters import ParameterSchema as _Schema
+
+        if not isinstance(schema, _Schema):
+            raise TypeError(f"Expected ParameterSchema, got {type(schema).__name__}")
+
+        params: dict[str, Dimension] = {}
+        for name, pdef in schema.parameters.items():
+            if pdef.bounds is None:
+                raise ValueError(
+                    f"Parameter {name!r} has no bounds declared — "
+                    f"cannot create sweep dimension without bounds"
+                )
+            low, high = pdef.bounds
+            py_type = pdef.typedef.python_type
+            is_float = py_type is float or (
+                isinstance(py_type, type) and issubclass(py_type, float)
+            )
+            is_int = py_type is int or (
+                isinstance(py_type, type) and issubclass(py_type, int)
+            )
+            if is_float:
+                params[name] = Continuous(min_val=float(low), max_val=float(high))
+            elif is_int:
+                params[name] = Integer(min_val=int(low), max_val=int(high))
+            else:
+                raise TypeError(
+                    f"Parameter {name!r} has type {py_type.__name__} — "
+                    f"only float and int are supported for automatic "
+                    f"dimension creation"
+                )
+        return cls(params=params)
+
+    def validate_against_schema(self, schema: ParameterSchema) -> list[SchemaViolation]:
+        """Check that this space respects the declared parameter schema.
+
+        Returns a list of violations. Empty list means the space is
+        compatible with the schema.
+
+        Requires ``gds-framework`` to be installed.
+        """
+        from gds.parameters import ParameterSchema as _Schema
+
+        if not isinstance(schema, _Schema):
+            raise TypeError(f"Expected ParameterSchema, got {type(schema).__name__}")
+
+        violations: list[SchemaViolation] = []
+
+        for name, dim in self.params.items():
+            # Check parameter exists in schema
+            pdef = schema.parameters.get(name)
+            if pdef is None:
+                violations.append(
+                    SchemaViolation(
+                        param=name,
+                        violation_type="missing_from_schema",
+                        message=(
+                            f"Parameter {name!r} is swept but not "
+                            f"declared in the schema"
+                        ),
+                    )
+                )
+                continue
+
+            # Check type compatibility
+            py_type = pdef.typedef.python_type
+            if isinstance(dim, Continuous) and py_type is not float:
+                violations.append(
+                    SchemaViolation(
+                        param=name,
+                        violation_type="type_mismatch",
+                        message=(
+                            f"Parameter {name!r}: Continuous dimension "
+                            f"but declared type is {py_type.__name__}"
+                        ),
+                    )
+                )
+            elif isinstance(dim, Integer) and py_type is not int:
+                violations.append(
+                    SchemaViolation(
+                        param=name,
+                        violation_type="type_mismatch",
+                        message=(
+                            f"Parameter {name!r}: Integer dimension "
+                            f"but declared type is {py_type.__name__}"
+                        ),
+                    )
+                )
+
+            # Check bounds compatibility
+            if pdef.bounds is not None and isinstance(dim, (Continuous, Integer)):
+                schema_low, schema_high = pdef.bounds
+                if dim.min_val < schema_low:
+                    violations.append(
+                        SchemaViolation(
+                            param=name,
+                            violation_type="out_of_bounds",
+                            message=(
+                                f"Parameter {name!r}: sweep min "
+                                f"{dim.min_val} < declared lower "
+                                f"bound {schema_low}"
+                            ),
+                        )
+                    )
+                if dim.max_val > schema_high:
+                    violations.append(
+                        SchemaViolation(
+                            param=name,
+                            violation_type="out_of_bounds",
+                            message=(
+                                f"Parameter {name!r}: sweep max "
+                                f"{dim.max_val} > declared upper "
+                                f"bound {schema_high}"
+                            ),
+                        )
+                    )
+
+            # Check typedef constraint at sweep boundaries
+            if pdef.typedef.constraint is not None and isinstance(
+                dim, (Continuous, Integer)
+            ):
+                if not pdef.typedef.check_value(dim.min_val):
+                    violations.append(
+                        SchemaViolation(
+                            param=name,
+                            violation_type="out_of_bounds",
+                            message=(
+                                f"Parameter {name!r}: sweep min "
+                                f"{dim.min_val} fails typedef constraint"
+                            ),
+                        )
+                    )
+                if not pdef.typedef.check_value(dim.max_val):
+                    violations.append(
+                        SchemaViolation(
+                            param=name,
+                            violation_type="out_of_bounds",
+                            message=(
+                                f"Parameter {name!r}: sweep max "
+                                f"{dim.max_val} fails typedef constraint"
+                            ),
+                        )
+                    )
+
+        return violations

--- a/packages/gds-psuu/gds_psuu/sweep.py
+++ b/packages/gds-psuu/gds_psuu/sweep.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from gds_sim import Model  # noqa: TC002
 from pydantic import BaseModel, ConfigDict
 
@@ -18,6 +20,10 @@ class Sweep(BaseModel):
 
     Drives the optimizer suggest/observe loop, delegating evaluation
     to the Evaluator which bridges to gds-sim.
+
+    If ``parameter_schema`` is provided, the sweep validates the
+    parameter space against the declared schema before starting.
+    Validation errors raise ``ValueError``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
@@ -29,9 +35,13 @@ class Sweep(BaseModel):
     objective: Objective | None = None
     timesteps: int = 100
     runs: int = 1
+    parameter_schema: Any = None
 
     def run(self) -> SweepResults:
         """Execute the sweep and return results."""
+        if self.parameter_schema is not None:
+            self._validate_schema()
+
         kpi_names = [k.name for k in self.kpis]
         self.optimizer.setup(self.space, kpi_names)
 
@@ -54,3 +64,17 @@ class Sweep(BaseModel):
             kpi_names=kpi_names,
             optimizer_name=type(self.optimizer).__name__,
         )
+
+    def _validate_schema(self) -> None:
+        """Validate the parameter space against the declared schema."""
+        from gds.verification.findings import Severity
+
+        from gds_psuu.checks import check_parameter_space_compatibility
+
+        findings = check_parameter_space_compatibility(
+            self.space, self.parameter_schema
+        )
+        errors = [f for f in findings if f.severity == Severity.ERROR]
+        if errors:
+            messages = "; ".join(f.message for f in errors)
+            raise ValueError(f"Parameter space violates declared schema: {messages}")

--- a/packages/gds-psuu/pyproject.toml
+++ b/packages/gds-psuu/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 pandas = ["pandas>=2.0"]
 bayesian = ["optuna>=4.0"]
+validation = ["gds-framework>=0.2.3"]
 
 [project.urls]
 Homepage = "https://github.com/BlockScience/gds-core"

--- a/packages/gds-psuu/tests/test_schema_validation.py
+++ b/packages/gds-psuu/tests/test_schema_validation.py
@@ -1,0 +1,206 @@
+"""Tests for ParameterSpace <-> ParameterSchema integration.
+
+Covers from_parameter_schema(), validate_against_schema(), and the
+PSUU-001 check function.
+"""
+
+from __future__ import annotations
+
+import pytest
+from gds.parameters import ParameterDef, ParameterSchema
+from gds.types.typedef import TypeDef
+from gds.verification.findings import Severity
+
+from gds_psuu.checks import check_parameter_space_compatibility
+from gds_psuu.space import Continuous, Integer, ParameterSpace
+
+# ── Helpers ──────────────────────────────────────────────────
+
+_float_td = TypeDef(name="Rate", python_type=float)
+_int_td = TypeDef(name="Count", python_type=int)
+_str_td = TypeDef(name="Label", python_type=str)
+_positive_float = TypeDef(
+    name="PositiveFloat",
+    python_type=float,
+    constraint=lambda x: x > 0.0,
+)
+
+
+def _schema(*params: ParameterDef) -> ParameterSchema:
+    """Build a ParameterSchema from a list of ParameterDef."""
+    s = ParameterSchema()
+    for p in params:
+        s = s.add(p)
+    return s
+
+
+# ── from_parameter_schema ────────────────────────────────────
+
+
+class TestFromParameterSchema:
+    def test_float_with_bounds(self) -> None:
+        schema = _schema(
+            ParameterDef(name="alpha", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace.from_parameter_schema(schema)
+        dim = space.params["alpha"]
+        assert isinstance(dim, Continuous)
+        assert dim.min_val == 0.0
+        assert dim.max_val == 1.0
+
+    def test_int_with_bounds(self) -> None:
+        schema = _schema(ParameterDef(name="n", typedef=_int_td, bounds=(1, 10)))
+        space = ParameterSpace.from_parameter_schema(schema)
+        dim = space.params["n"]
+        assert isinstance(dim, Integer)
+        assert dim.min_val == 1
+        assert dim.max_val == 10
+
+    def test_mixed_params(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.01, 0.5)),
+            ParameterDef(name="count", typedef=_int_td, bounds=(1, 100)),
+        )
+        space = ParameterSpace.from_parameter_schema(schema)
+        assert len(space.params) == 2
+        assert isinstance(space.params["rate"], Continuous)
+        assert isinstance(space.params["count"], Integer)
+
+    def test_no_bounds_raises(self) -> None:
+        schema = _schema(ParameterDef(name="alpha", typedef=_float_td))
+        with pytest.raises(ValueError, match="no bounds declared"):
+            ParameterSpace.from_parameter_schema(schema)
+
+    def test_unsupported_type_raises(self) -> None:
+        schema = _schema(ParameterDef(name="label", typedef=_str_td, bounds=("a", "z")))
+        with pytest.raises(TypeError, match="only float and int"):
+            ParameterSpace.from_parameter_schema(schema)
+
+
+# ── validate_against_schema ──────────────────────────────────
+
+
+class TestValidateAgainstSchema:
+    def test_compatible_returns_empty(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Continuous(min_val=0.0, max_val=1.0)})
+        violations = space.validate_against_schema(schema)
+        assert violations == []
+
+    def test_missing_from_schema(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(
+            params={"unknown_param": Continuous(min_val=0.0, max_val=1.0)}
+        )
+        violations = space.validate_against_schema(schema)
+        assert len(violations) == 1
+        assert violations[0].violation_type == "missing_from_schema"
+        assert violations[0].param == "unknown_param"
+
+    def test_sweep_min_below_bound(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Continuous(min_val=-0.5, max_val=0.5)})
+        violations = space.validate_against_schema(schema)
+        types = [v.violation_type for v in violations]
+        assert "out_of_bounds" in types
+
+    def test_sweep_max_above_bound(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Continuous(min_val=0.5, max_val=1.5)})
+        violations = space.validate_against_schema(schema)
+        types = [v.violation_type for v in violations]
+        assert "out_of_bounds" in types
+
+    def test_type_mismatch_continuous_vs_int(self) -> None:
+        schema = _schema(ParameterDef(name="n", typedef=_int_td, bounds=(1, 10)))
+        space = ParameterSpace(params={"n": Continuous(min_val=1.0, max_val=10.0)})
+        violations = space.validate_against_schema(schema)
+        types = [v.violation_type for v in violations]
+        assert "type_mismatch" in types
+
+    def test_type_mismatch_integer_vs_float(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Integer(min_val=0, max_val=1)})
+        violations = space.validate_against_schema(schema)
+        types = [v.violation_type for v in violations]
+        assert "type_mismatch" in types
+
+    def test_typedef_constraint_violation(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_positive_float, bounds=(0.0, 1.0))
+        )
+        # min_val=0.0 fails the constraint (x > 0.0)
+        space = ParameterSpace(params={"rate": Continuous(min_val=0.0, max_val=0.5)})
+        violations = space.validate_against_schema(schema)
+        assert any(
+            v.violation_type == "out_of_bounds" and "typedef constraint" in v.message
+            for v in violations
+        )
+
+    def test_schema_without_bounds_skips_bound_check(self) -> None:
+        """If the schema has no bounds, only type/existence is checked."""
+        schema = _schema(ParameterDef(name="rate", typedef=_float_td))
+        space = ParameterSpace(
+            params={"rate": Continuous(min_val=-100.0, max_val=100.0)}
+        )
+        violations = space.validate_against_schema(schema)
+        assert violations == []
+
+    def test_multiple_violations(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(
+            params={
+                "rate": Continuous(min_val=-1.0, max_val=2.0),
+                "ghost": Continuous(min_val=0.0, max_val=1.0),
+            }
+        )
+        violations = space.validate_against_schema(schema)
+        # "ghost" missing + "rate" has two bound violations
+        assert len(violations) >= 3
+
+
+# ── check_parameter_space_compatibility (PSUU-001) ──────────
+
+
+class TestPSUU001:
+    def test_compatible_returns_info_pass(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Continuous(min_val=0.0, max_val=1.0)})
+        findings = check_parameter_space_compatibility(space, schema)
+        assert len(findings) == 1
+        assert findings[0].passed is True
+        assert findings[0].check_id == "PSUU-001"
+        assert findings[0].severity == Severity.INFO
+
+    def test_out_of_bounds_returns_error(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"rate": Continuous(min_val=-1.0, max_val=0.5)})
+        findings = check_parameter_space_compatibility(space, schema)
+        assert any(f.severity == Severity.ERROR and not f.passed for f in findings)
+
+    def test_missing_param_returns_warning(self) -> None:
+        schema = _schema(
+            ParameterDef(name="rate", typedef=_float_td, bounds=(0.0, 1.0))
+        )
+        space = ParameterSpace(params={"ghost": Continuous(min_val=0.0, max_val=1.0)})
+        findings = check_parameter_space_compatibility(space, schema)
+        warnings = [f for f in findings if f.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert warnings[0].passed is False
+        assert "ghost" in warnings[0].source_elements

--- a/packages/gds-psuu/tests/test_sweep.py
+++ b/packages/gds-psuu/tests/test_sweep.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+from gds.parameters import ParameterDef, ParameterSchema
+from gds.types.typedef import TypeDef
+
 from gds_psuu import (
     KPI,
     Continuous,
@@ -124,3 +128,75 @@ class TestSweep:
         assert len(results.evaluations) == 2
         for ev in results.evaluations:
             assert ev.run_count == 3
+
+
+class TestSweepSchemaValidation:
+    """Tests for optional parameter_schema validation in Sweep.run()."""
+
+    def test_valid_schema_runs_successfully(self, simple_model: Model) -> None:
+        rate_td = TypeDef(name="Rate", python_type=float)
+        schema = ParameterSchema().add(
+            ParameterDef(name="growth_rate", typedef=rate_td, bounds=(0.0, 1.0))
+        )
+        sweep = Sweep(
+            model=simple_model,
+            space=ParameterSpace(
+                params={"growth_rate": Continuous(min_val=0.01, max_val=0.1)}
+            ),
+            kpis=[
+                KPI(
+                    name="final_pop",
+                    fn=lambda r: final_state_mean(r, "population"),
+                )
+            ],
+            optimizer=GridSearchOptimizer(n_steps=2),
+            timesteps=5,
+            runs=1,
+            parameter_schema=schema,
+        )
+        results = sweep.run()
+        assert len(results.evaluations) == 2
+
+    def test_violated_schema_raises(self, simple_model: Model) -> None:
+        rate_td = TypeDef(name="Rate", python_type=float)
+        schema = ParameterSchema().add(
+            ParameterDef(name="growth_rate", typedef=rate_td, bounds=(0.0, 0.05))
+        )
+        sweep = Sweep(
+            model=simple_model,
+            space=ParameterSpace(
+                params={"growth_rate": Continuous(min_val=0.01, max_val=0.1)}
+            ),
+            kpis=[
+                KPI(
+                    name="final_pop",
+                    fn=lambda r: final_state_mean(r, "population"),
+                )
+            ],
+            optimizer=GridSearchOptimizer(n_steps=2),
+            timesteps=5,
+            runs=1,
+            parameter_schema=schema,
+        )
+        with pytest.raises(ValueError, match="violates declared schema"):
+            sweep.run()
+
+    def test_no_schema_skips_validation(self, simple_model: Model) -> None:
+        """Sweep without parameter_schema should run without validation."""
+        sweep = Sweep(
+            model=simple_model,
+            space=ParameterSpace(
+                params={"growth_rate": Continuous(min_val=0.01, max_val=0.1)}
+            ),
+            kpis=[
+                KPI(
+                    name="final_pop",
+                    fn=lambda r: final_state_mean(r, "population"),
+                )
+            ],
+            optimizer=GridSearchOptimizer(n_steps=2),
+            timesteps=5,
+            runs=1,
+        )
+        results = sweep.run()
+        assert len(results.evaluations) == 2


### PR DESCRIPTION
## Summary
- Add `ParameterSpace.from_parameter_schema()` for automatic dimension creation from `ParameterDef` entries
- Add `ParameterSpace.validate_against_schema()` returning typed `SchemaViolation` objects for missing params, type mismatches, and bound violations
- Add PSUU-001 check function following the GDS `Finding` pattern
- Integrate validation into `Sweep.run()` via optional `parameter_schema` field — ERROR violations raise `ValueError` before sweep starts
- All gds-framework imports are lazy (gds-framework is an optional dependency)

## Test plan
- [x] 17 new tests for schema validation (from_parameter_schema, validate_against_schema, PSUU-001)
- [x] 3 new sweep integration tests
- [x] 147 psuu tests pass, 519 framework tests pass
- [x] Ruff clean

Closes #160