### PR TITLE
chore: bump versions and changelog for Tier 0 + Tier 1 release

### DIFF
--- a/packages/gds-analysis/pyproject.toml
+++ b/packages/gds-analysis/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "gds-sim>=0.1.0",
 ]
 

--- a/packages/gds-business/gds_business/__init__.py
+++ b/packages/gds-business/gds_business/__init__.py
@@ -7,7 +7,7 @@ All downstream GDS tooling works immediately — canonical projection,
 semantic checks, SpecQuery, serialization, gds-viz.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # ── Common ─────────────────────────────────────────────────
 from gds_business.common.errors import BizCompilationError, BizError, BizValidationError

--- a/packages/gds-business/pyproject.toml
+++ b/packages/gds-business/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "pydantic>=2.10",
 ]
 

--- a/packages/gds-control/gds_control/__init__.py
+++ b/packages/gds-control/gds_control/__init__.py
@@ -6,7 +6,7 @@ All downstream GDS tooling works immediately — canonical projection,
 semantic checks, SpecQuery, serialization, gds-viz.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # ── DSL declarations ────────────────────────────────────────
 from gds_control.dsl.elements import Controller, Input, Sensor, State

--- a/packages/gds-control/pyproject.toml
+++ b/packages/gds-control/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "pydantic>=2.10",
 ]
 

--- a/packages/gds-examples/pyproject.toml
+++ b/packages/gds-examples/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "gds-viz>=0.1.0",
     "gds-control>=0.1.0",
     "gds-stockflow>=0.1.0",

--- a/packages/gds-framework/gds/__init__.py
+++ b/packages/gds-framework/gds/__init__.py
@@ -6,7 +6,7 @@ cybernetics (Ghani, Hedges et al.) into a single, dependency-light
 Python framework.
 """
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 
 # ── Composition algebra ─────────────────────────────────────
 from gds.blocks.base import AtomicBlock, Block

--- a/packages/gds-games/ogs/__init__.py
+++ b/packages/gds-games/ogs/__init__.py
@@ -1,6 +1,6 @@
 """Open Games — Typed DSL for Compositional Game Theory."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from ogs.dsl.base import OpenGame
 from ogs.dsl.compile import compile_to_ir

--- a/packages/gds-games/pyproject.toml
+++ b/packages/gds-games/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "pydantic>=2.10",
     "typer>=0.15",
     "jinja2>=3.1",

--- a/packages/gds-owl/gds_owl/__init__.py
+++ b/packages/gds-owl/gds_owl/__init__.py
@@ -1,6 +1,6 @@
 """gds-owl — OWL/Turtle, SHACL, and SPARQL for gds-framework specifications."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from gds_owl._namespace import (
     GDS,

--- a/packages/gds-owl/pyproject.toml
+++ b/packages/gds-owl/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "rdflib>=7.0",
 ]
 

--- a/packages/gds-psuu/gds_psuu/__init__.py
+++ b/packages/gds-psuu/gds_psuu/__init__.py
@@ -1,6 +1,6 @@
 """gds-psuu: Parameter space search under uncertainty for the GDS ecosystem."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from gds_psuu.checks import check_parameter_space_compatibility
 from gds_psuu.errors import PsuuError, PsuuSearchError, PsuuValidationError

--- a/packages/gds-psuu/pyproject.toml
+++ b/packages/gds-psuu/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 pandas = ["pandas>=2.0"]
 bayesian = ["optuna>=4.0"]
-validation = ["gds-framework>=0.2.3"]
+validation = ["gds-framework>=0.3.0"]
 
 [project.urls]
 Homepage = "https://github.com/BlockScience/gds-core"

--- a/packages/gds-software/gds_software/__init__.py
+++ b/packages/gds-software/gds_software/__init__.py
@@ -7,7 +7,7 @@ All downstream GDS tooling works immediately — canonical projection,
 semantic checks, SpecQuery, serialization, gds-viz.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # ── Common ─────────────────────────────────────────────────
 from gds_software.common.errors import SWCompilationError, SWError, SWValidationError

--- a/packages/gds-software/pyproject.toml
+++ b/packages/gds-software/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "pydantic>=2.10",
 ]
 

--- a/packages/gds-stockflow/pyproject.toml
+++ b/packages/gds-stockflow/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "pydantic>=2.10",
 ]
 

--- a/packages/gds-stockflow/stockflow/__init__.py
+++ b/packages/gds-stockflow/stockflow/__init__.py
@@ -6,7 +6,7 @@ All downstream GDS tooling works immediately — canonical projection,
 semantic checks, SpecQuery, serialization, gds-viz.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # ── DSL declarations ────────────────────────────────────────
 from stockflow.dsl.elements import Auxiliary, Converter, Flow, Stock

--- a/packages/gds-symbolic/pyproject.toml
+++ b/packages/gds-symbolic/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
     "gds-control>=0.1.0",
     "pydantic>=2.10",
 ]

--- a/packages/gds-viz/pyproject.toml
+++ b/packages/gds-viz/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "gds-framework>=0.2.3",
+    "gds-framework>=0.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Version bumps for 8 packages
- Changelog with rationale for all changes driven by Zargham + Jamsheed reviews
- All packages now require gds-framework>=0.3.0

## Versions
| Package | Old | New |
|---------|-----|-----|
| gds-framework | 0.2.3 | 0.3.0 |
| gds-owl | 0.1.0 | 0.2.0 |
| gds-psuu | 0.2.0 | 0.2.1 |
| gds-stockflow | 0.1.0 | 0.1.1 |
| gds-control | 0.1.0 | 0.1.1 |
| gds-games | 0.3.1 | 0.3.2 |
| gds-software | 0.1.0 | 0.1.1 |
| gds-business | 0.1.0 | 0.1.1 |