### PR TITLE
feat(gds-sysml): add SysML v2 bridge package via OSLC RDF vocabulary

### DIFF
--- a/packages/gds-sysml/README.md
+++ b/packages/gds-sysml/README.md
@@ -1,0 +1,19 @@
+# gds-sysml
+
+SysML v2 bridge for gds-framework via OSLC RDF vocabulary.
+
+## Installation
+
+```bash
+uv add gds-sysml
+```
+
+## Usage
+
+```python
+from gds_sysml import sysml_to_spec
+
+spec = sysml_to_spec("path/to/model.sysml")
+print(spec.name)
+print(list(spec.blocks.keys()))
+```

--- a/packages/gds-sysml/gds_sysml/__init__.py
+++ b/packages/gds-sysml/gds_sysml/__init__.py
@@ -1,0 +1,32 @@
+"""gds-sysml — SysML v2 bridge for gds-framework via OSLC RDF vocabulary."""
+
+__version__ = "0.1.0"
+
+from gds_sysml._namespace import GDS_SYSML, SYSML_OSLC
+from gds_sysml.import_ import sysml_to_spec
+from gds_sysml.model import (
+    GDSAnnotation,
+    SysMLAction,
+    SysMLAttribute,
+    SysMLConnection,
+    SysMLModel,
+    SysMLPart,
+    SysMLPort,
+)
+from gds_sysml.parser.regex import parse_sysml
+from gds_sysml.rdf import sysml_to_rdf
+
+__all__ = [
+    "GDS_SYSML",
+    "SYSML_OSLC",
+    "GDSAnnotation",
+    "SysMLAction",
+    "SysMLAttribute",
+    "SysMLConnection",
+    "SysMLModel",
+    "SysMLPart",
+    "SysMLPort",
+    "parse_sysml",
+    "sysml_to_rdf",
+    "sysml_to_spec",
+]

--- a/packages/gds-sysml/gds_sysml/_namespace.py
+++ b/packages/gds-sysml/gds_sysml/_namespace.py
@@ -1,0 +1,15 @@
+"""OSLC SysML v2 and GDS-SysML namespace constants."""
+
+from rdflib import Namespace
+
+# OSLC SysML v2 vocabulary (normative, published by OMG/OSLC)
+SYSML_OSLC = Namespace("https://www.omg.org/spec/SysML/2.0/")
+
+# GDS-SysML bridge namespace (for bridge-specific predicates)
+GDS_SYSML = Namespace("https://gds.block.science/ontology/sysml/")
+
+# Standard prefix bindings
+PREFIXES: dict[str, Namespace] = {
+    "sysml": SYSML_OSLC,
+    "gds-sysml": GDS_SYSML,
+}

--- a/packages/gds-sysml/gds_sysml/import_.py
+++ b/packages/gds-sysml/gds_sysml/import_.py
@@ -1,0 +1,54 @@
+"""End-to-end SysML v2 → GDSSpec import pipeline.
+
+Pipeline:  .sysml text → parse_sysml() → SysMLModel → sysml_to_rdf() → RDF Graph
+           → gds_owl.graph_to_spec() → GDSSpec
+
+This module provides the high-level ``sysml_to_spec()`` entry point that
+orchestrates the full pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gds_owl.import_ import graph_to_spec
+from gds_sysml.model import SysMLModel
+from gds_sysml.parser.regex import parse_sysml
+from gds_sysml.rdf import sysml_to_rdf
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from gds.spec import GDSSpec
+
+
+def sysml_to_spec(
+    source: str | Path | SysMLModel,
+    *,
+    base_uri: str = "https://gds.block.science/instance/",
+) -> GDSSpec:
+    """Import a SysML v2 model as a GDSSpec.
+
+    Orchestrates the full pipeline: parse → RDF → GDSSpec.
+
+    Args:
+        source: One of:
+            - A ``str`` containing SysML v2 textual notation
+            - A ``Path`` to a ``.sysml`` file
+            - A pre-parsed ``SysMLModel``
+        base_uri: Base URI for RDF instance data.
+
+    Returns:
+        A fully populated GDSSpec reconstructed from the SysML model.
+
+    Example::
+
+        from gds_sysml import sysml_to_spec
+
+        spec = sysml_to_spec("path/to/model.sysml")
+        print(spec.name)
+        print(list(spec.blocks.keys()))
+    """
+    model = source if isinstance(source, SysMLModel) else parse_sysml(source)
+    graph = sysml_to_rdf(model, base_uri=base_uri)
+    return graph_to_spec(graph)

--- a/packages/gds-sysml/gds_sysml/model.py
+++ b/packages/gds-sysml/gds_sysml/model.py
@@ -1,0 +1,138 @@
+"""SysML v2 intermediate model — parsed representation before RDF conversion.
+
+These Pydantic models capture the structural elements of a SysML v2 textual
+notation file with @GDS* metadata annotations. They are the output of the
+parser layer and the input to the RDF conversion layer.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class GDSAnnotation(BaseModel, frozen=True):
+    """A @GDS* metadata annotation on a SysML element.
+
+    SysML v2 ``metadata def`` usage: ``@GDSMechanism``, ``@GDSStateVariable``,
+    ``@GDSParameter``, etc.  These are valid SysML v2 and parsed as first-class
+    elements by both SysON and the OMG Pilot.
+
+    Attributes:
+        kind: The annotation type without the ``@GDS`` prefix.
+            Examples: ``"Mechanism"``, ``"Policy"``, ``"BoundaryAction"``,
+            ``"StateVariable"``, ``"Parameter"``, ``"Dynamics"``.
+        properties: Key-value metadata from the annotation body.
+            For ``@GDSDynamics``: ``{"reads": ["x", "y"], "writes": ["z"]}``.
+            For ``@GDSParameter``: ``{"units": "kg/m^2"}``.
+    """
+
+    kind: str
+    properties: dict[str, str | list[str]] = Field(default_factory=dict)
+
+
+class SysMLAttribute(BaseModel, frozen=True):
+    """An ``attribute`` usage within a part or action definition.
+
+    Attributes:
+        name: Attribute name (e.g. ``"temperature"``).
+        type_name: SysML type reference (e.g. ``"Real"``, ``"Boolean"``).
+        default_value: Optional default value as string.
+        annotations: @GDS* metadata attached to this attribute.
+    """
+
+    name: str
+    type_name: str = ""
+    default_value: str = ""
+    annotations: list[GDSAnnotation] = Field(default_factory=list)
+
+
+class SysMLPort(BaseModel, frozen=True):
+    """A ``port`` definition/usage on a part or action.
+
+    Attributes:
+        name: Port name (e.g. ``"temperatureOut"``).
+        direction: Port direction — ``"in"``, ``"out"``, or ``"inout"``.
+        type_name: Port type reference (e.g. ``"Temperature"``).
+    """
+
+    name: str
+    direction: str = ""
+    type_name: str = ""
+
+
+class SysMLAction(BaseModel, frozen=True):
+    """An ``action def`` / ``action usage`` — maps to GDS blocks.
+
+    The @GDS* annotation determines the GDS role:
+    - ``@GDSBoundaryAction`` → BoundaryAction
+    - ``@GDSPolicy`` → Policy
+    - ``@GDSMechanism`` → Mechanism
+    - ``@GDSControlAction`` → ControlAction
+    - No annotation → defaults to Policy
+
+    Attributes:
+        name: Action name.
+        annotations: @GDS* metadata (role, dynamics, etc.).
+        ports: Ports declared on this action.
+        attributes: Attributes declared within this action.
+        nested_actions: Nested action usages (composition structure).
+    """
+
+    name: str
+    annotations: list[GDSAnnotation] = Field(default_factory=list)
+    ports: list[SysMLPort] = Field(default_factory=list)
+    attributes: list[SysMLAttribute] = Field(default_factory=list)
+    nested_actions: list[str] = Field(default_factory=list)
+
+
+class SysMLPart(BaseModel, frozen=True):
+    """A ``part def`` / ``part usage`` — maps to GDS entities.
+
+    Attributes:
+        name: Part name (e.g. ``"Spacecraft"``).
+        annotations: @GDS* metadata.
+        attributes: State variables and parameters declared on this part.
+        ports: Ports declared on this part.
+        nested_parts: Names of nested part usages.
+    """
+
+    name: str
+    annotations: list[GDSAnnotation] = Field(default_factory=list)
+    attributes: list[SysMLAttribute] = Field(default_factory=list)
+    ports: list[SysMLPort] = Field(default_factory=list)
+    nested_parts: list[str] = Field(default_factory=list)
+
+
+class SysMLConnection(BaseModel, frozen=True):
+    """A ``connection usage`` — maps to GDS wiring.
+
+    Attributes:
+        name: Optional connection name.
+        source: Source endpoint (e.g. ``"sensor.temperatureOut"``).
+        target: Target endpoint (e.g. ``"controller.temperatureIn"``).
+    """
+
+    name: str = ""
+    source: str = ""
+    target: str = ""
+
+
+class SysMLModel(BaseModel):
+    """Complete parsed SysML v2 model — the output of the parser layer.
+
+    Captures all structural elements and @GDS* annotations needed to
+    build a GDSSpec via the RDF pipeline.
+
+    Attributes:
+        name: Model/package name.
+        parts: Part definitions (→ entities).
+        actions: Action definitions (→ blocks).
+        connections: Connection usages (→ wirings).
+        metadata_defs: Raw ``metadata def`` declarations for @GDS* types.
+    """
+
+    name: str = ""
+    parts: dict[str, SysMLPart] = Field(default_factory=dict)
+    actions: dict[str, SysMLAction] = Field(default_factory=dict)
+    connections: list[SysMLConnection] = Field(default_factory=list)
+    metadata_defs: list[str] = Field(default_factory=list)

--- a/packages/gds-sysml/gds_sysml/parser/__init__.py
+++ b/packages/gds-sysml/gds_sysml/parser/__init__.py
@@ -1,0 +1,1 @@
+"""SysML v2 parsers — tiered from regex to external tool backends."""

--- a/packages/gds-sysml/gds_sysml/parser/regex.py
+++ b/packages/gds-sysml/gds_sysml/parser/regex.py
@@ -1,0 +1,332 @@
+"""Regex-based SysML v2 parser with @GDS* annotation extraction.
+
+Tier 0 parser: works on SysML v2 textual notation files without requiring
+any external tooling (SysON, OMG Pilot, etc.). Handles the subset of SysML v2
+syntax needed for GDS model interchange:
+
+- ``package`` declarations
+- ``metadata def`` declarations (for @GDS* annotation types)
+- ``part def`` / ``part usage`` (→ entities, state variables)
+- ``action def`` / ``action usage`` (→ blocks with roles)
+- ``port def`` / ``port usage`` (→ interface ports)
+- ``attribute usage`` (→ state variables, parameters)
+- ``connection usage`` (→ wirings)
+- ``@GDS*`` metadata annotations with property bodies
+
+Limitations:
+- Does not handle full SysML v2 expression language
+- Nesting is tracked by brace depth, not a full AST
+- Imports and library references are not resolved
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from gds_sysml.model import (
+    GDSAnnotation,
+    SysMLAction,
+    SysMLAttribute,
+    SysMLConnection,
+    SysMLModel,
+    SysMLPart,
+    SysMLPort,
+)
+
+# ── Regex patterns ──────────────────────────────────────────────
+
+# @GDS* annotation: @GDSMechanism, @GDSPolicy { reads = [...]; }
+_GDS_ANNOTATION = re.compile(
+    r"@GDS(\w+)"
+    r"(?:\s*\{([^}]*)\})?"  # optional { body }
+)
+
+# metadata def GDSFoo { ... }
+_METADATA_DEF = re.compile(r"metadata\s+def\s+(\w+)")
+
+# package Foo { ... }
+_PACKAGE = re.compile(r"package\s+(\w+)")
+
+# part def Foo { ... }  or  part foo : Foo { ... }
+_PART_DEF = re.compile(r"part\s+def\s+(\w+)")
+_PART_USAGE = re.compile(r"part\s+(\w+)\s*:\s*(\w+)")
+
+# action def Foo { ... }  or  action foo : Foo { ... }
+_ACTION_DEF = re.compile(r"action\s+def\s+(\w+)")
+_ACTION_USAGE = re.compile(r"action\s+(\w+)\s*:\s*(\w+)")
+
+# port def Foo { ... }  or  port foo : Foo
+_PORT_DEF = re.compile(r"port\s+def\s+(\w+)")
+_PORT_USAGE = re.compile(r"(in|out|inout)?\s*port\s+(\w+)\s*:\s*(\w+)")
+
+# attribute foo : Type  or  attribute foo : Type = value
+_ATTRIBUTE = re.compile(
+    r"attribute\s+(\w+)\s*:\s*(\w+)"
+    r"(?:\s*=\s*(.+?))?"
+    r"\s*;"
+)
+
+# connection usage: connect source to target
+_CONNECTION = re.compile(r"connect\s+([\w.]+)\s+to\s+([\w.]+)")
+
+# flow usage: flow source to target (SysML v2 alternate syntax)
+_FLOW = re.compile(r"flow\s+([\w.]+)\s+to\s+([\w.]+)")
+
+# ── Annotation property parser ──────────────────────────────────
+
+
+def _parse_annotation_body(body: str) -> dict[str, str | list[str]]:
+    """Parse the body of a @GDS* annotation into key-value pairs.
+
+    Handles:
+    - ``key = "value";``
+    - ``key = value;``
+    - ``key = [a, b, c];`` (list values)
+    """
+    props: dict[str, str | list[str]] = {}
+    if not body:
+        return props
+
+    for match in re.finditer(
+        r"(\w+)\s*=\s*"
+        r"(?:"
+        r"\[([^\]]*)\]"  # list value
+        r"|"
+        r'"([^"]*)"'  # quoted string
+        r"|"
+        r"(\S+)"  # bare value
+        r")\s*;?",
+        body,
+    ):
+        key = match.group(1)
+        if match.group(2) is not None:
+            # List value: [a, b, c]
+            items = [
+                item.strip().strip('"').strip("'")
+                for item in match.group(2).split(",")
+                if item.strip()
+            ]
+            props[key] = items
+        elif match.group(3) is not None:
+            props[key] = match.group(3)
+        elif match.group(4) is not None:
+            props[key] = match.group(4).rstrip(";")
+
+    return props
+
+
+def _extract_annotations(line: str) -> list[GDSAnnotation]:
+    """Extract all @GDS* annotations from a line."""
+    annotations = []
+    for m in _GDS_ANNOTATION.finditer(line):
+        kind = m.group(1)
+        body = m.group(2) or ""
+        props = _parse_annotation_body(body)
+        annotations.append(GDSAnnotation(kind=kind, properties=props))
+    return annotations
+
+
+# ── Main parser ─────────────────────────────────────────────────
+
+
+def parse_sysml(source: str | Path) -> SysMLModel:
+    """Parse a SysML v2 textual notation file into a SysMLModel.
+
+    Args:
+        source: Either the SysML source text directly, or a Path to a
+            ``.sysml`` file.
+
+    Returns:
+        A populated SysMLModel with parts, actions, connections, and
+        @GDS* annotations extracted.
+    """
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8")
+    elif "\n" not in source and source.endswith(".sysml"):
+        text = Path(source).read_text(encoding="utf-8")
+    else:
+        text = source
+
+    model = SysMLModel()
+
+    # State tracking
+    context_stack: list[tuple[str, str]] = []  # (kind, name)
+    brace_depth = 0
+    pending_annotations: list[GDSAnnotation] = []
+
+    # Collect all lines, stripping comments
+    lines = _strip_comments(text)
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Count braces for depth tracking
+        open_braces = stripped.count("{")
+        close_braces = stripped.count("}")
+
+        # Extract @GDS* annotations (they precede the element they annotate)
+        line_annotations = _extract_annotations(stripped)
+        if line_annotations and not any(
+            p.search(stripped)
+            for p in [
+                _PART_DEF,
+                _ACTION_DEF,
+                _PORT_DEF,
+                _PORT_USAGE,
+                _ATTRIBUTE,
+                _PART_USAGE,
+                _ACTION_USAGE,
+            ]
+        ):
+            pending_annotations.extend(line_annotations)
+            brace_depth += open_braces - close_braces
+            continue
+
+        # Merge pending annotations with line annotations
+        all_annotations = pending_annotations + line_annotations
+        pending_annotations = []
+
+        # Package declaration
+        m = _PACKAGE.search(stripped)
+        if m and not model.name:
+            model.name = m.group(1)
+
+        # Metadata def
+        m = _METADATA_DEF.search(stripped)
+        if m:
+            model.metadata_defs.append(m.group(1))
+
+        # Part def
+        m = _PART_DEF.search(stripped)
+        if m:
+            name = m.group(1)
+            part = SysMLPart(name=name, annotations=all_annotations)
+            model.parts[name] = part
+            if open_braces > close_braces:
+                context_stack.append(("part", name))
+
+        # Action def
+        m = _ACTION_DEF.search(stripped)
+        if m:
+            name = m.group(1)
+            action = SysMLAction(name=name, annotations=all_annotations)
+            model.actions[name] = action
+            if open_braces > close_braces:
+                context_stack.append(("action", name))
+
+        # Part usage (nested)
+        m = _PART_USAGE.search(stripped)
+        if m and context_stack:
+            usage_name = m.group(1)
+            parent_kind, parent_name = context_stack[-1]
+            if parent_kind == "part" and parent_name in model.parts:
+                old = model.parts[parent_name]
+                model.parts[parent_name] = SysMLPart(
+                    name=old.name,
+                    annotations=old.annotations,
+                    attributes=old.attributes,
+                    ports=old.ports,
+                    nested_parts=[*old.nested_parts, usage_name],
+                )
+
+        # Action usage (nested)
+        m = _ACTION_USAGE.search(stripped)
+        if m and context_stack:
+            usage_name = m.group(1)
+            parent_kind, parent_name = context_stack[-1]
+            if parent_kind == "action" and parent_name in model.actions:
+                old = model.actions[parent_name]
+                model.actions[parent_name] = SysMLAction(
+                    name=old.name,
+                    annotations=old.annotations,
+                    ports=old.ports,
+                    attributes=old.attributes,
+                    nested_actions=[*old.nested_actions, usage_name],
+                )
+
+        # Port usage
+        m = _PORT_USAGE.search(stripped)
+        if m and context_stack:
+            direction = m.group(1) or ""
+            port_name = m.group(2)
+            port_type = m.group(3)
+            port = SysMLPort(name=port_name, direction=direction, type_name=port_type)
+            parent_kind, parent_name = context_stack[-1]
+            if parent_kind == "action" and parent_name in model.actions:
+                old = model.actions[parent_name]
+                model.actions[parent_name] = SysMLAction(
+                    name=old.name,
+                    annotations=old.annotations,
+                    ports=[*old.ports, port],
+                    attributes=old.attributes,
+                    nested_actions=old.nested_actions,
+                )
+            elif parent_kind == "part" and parent_name in model.parts:
+                old = model.parts[parent_name]
+                model.parts[parent_name] = SysMLPart(
+                    name=old.name,
+                    annotations=old.annotations,
+                    attributes=old.attributes,
+                    ports=[*old.ports, port],
+                    nested_parts=old.nested_parts,
+                )
+
+        # Attribute usage
+        m = _ATTRIBUTE.search(stripped)
+        if m and context_stack:
+            attr = SysMLAttribute(
+                name=m.group(1),
+                type_name=m.group(2),
+                default_value=m.group(3) or "",
+                annotations=all_annotations,
+            )
+            parent_kind, parent_name = context_stack[-1]
+            if parent_kind == "part" and parent_name in model.parts:
+                old = model.parts[parent_name]
+                model.parts[parent_name] = SysMLPart(
+                    name=old.name,
+                    annotations=old.annotations,
+                    attributes=[*old.attributes, attr],
+                    ports=old.ports,
+                    nested_parts=old.nested_parts,
+                )
+            elif parent_kind == "action" and parent_name in model.actions:
+                old = model.actions[parent_name]
+                model.actions[parent_name] = SysMLAction(
+                    name=old.name,
+                    annotations=old.annotations,
+                    ports=old.ports,
+                    attributes=[*old.attributes, attr],
+                    nested_actions=old.nested_actions,
+                )
+
+        # Connection usage
+        m = _CONNECTION.search(stripped) or _FLOW.search(stripped)
+        if m:
+            conn = SysMLConnection(source=m.group(1), target=m.group(2))
+            model.connections.append(conn)
+
+        # Update brace depth and context stack
+        brace_depth += open_braces - close_braces
+        for _ in range(close_braces):
+            if context_stack and brace_depth <= len(context_stack) - 1:
+                context_stack.pop()
+
+    return model
+
+
+def _strip_comments(text: str) -> list[str]:
+    """Remove // line comments and /* block comments */ from SysML source."""
+    # Remove block comments
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    lines = []
+    for line in text.splitlines():
+        # Remove line comments
+        comment_pos = line.find("//")
+        if comment_pos >= 0:
+            line = line[:comment_pos]
+        lines.append(line)
+    return lines

--- a/packages/gds-sysml/gds_sysml/parser/regex.py
+++ b/packages/gds-sysml/gds_sysml/parser/regex.py
@@ -155,8 +155,8 @@ def parse_sysml(source: str | Path) -> SysMLModel:
     brace_depth = 0
     pending_annotations: list[GDSAnnotation] = []
 
-    # Collect all lines, stripping comments
-    lines = _strip_comments(text)
+    # Collect all lines, stripping comments and joining multi-line annotations
+    lines = _join_multiline_annotations(_strip_comments(text))
 
     for line in lines:
         stripped = line.strip()
@@ -316,6 +316,38 @@ def parse_sysml(source: str | Path) -> SysMLModel:
                 context_stack.pop()
 
     return model
+
+
+def _join_multiline_annotations(lines: list[str]) -> list[str]:
+    """Join multi-line @GDS* annotation bodies into single lines.
+
+    When a ``@GDS*`` annotation opens a ``{`` that isn't closed on the same
+    line, subsequent lines are concatenated until the closing ``}`` is found.
+    This allows the regex-based parser to handle annotations formatted across
+    multiple lines (common in SysON and OMG Pilot output).
+    """
+    result: list[str] = []
+    accumulator = ""
+    brace_depth = 0
+
+    for line in lines:
+        if accumulator:
+            accumulator += " " + line.strip()
+            brace_depth += line.count("{") - line.count("}")
+            if brace_depth <= 0:
+                result.append(accumulator)
+                accumulator = ""
+                brace_depth = 0
+        elif _GDS_ANNOTATION.search(line) and line.count("{") > line.count("}"):
+            accumulator = line
+            brace_depth = line.count("{") - line.count("}")
+        else:
+            result.append(line)
+
+    if accumulator:
+        result.append(accumulator)
+
+    return result
 
 
 def _strip_comments(text: str) -> list[str]:

--- a/packages/gds-sysml/gds_sysml/rdf.py
+++ b/packages/gds-sysml/gds_sysml/rdf.py
@@ -397,8 +397,7 @@ def _emit_blocks(
         for port in action.ports:
             port_node = BNode()
             g.add((port_node, RDF.type, GDS_CORE["Port"]))
-            port_label = port.type_name or port.name
-            g.add((port_node, GDS_CORE["portName"], Literal(port_label)))
+            g.add((port_node, GDS_CORE["portName"], Literal(port.name)))
 
             if port.direction == "in":
                 g.add((iface_node, GDS_CORE["hasForwardIn"], port_node))
@@ -495,12 +494,15 @@ def _emit_wirings(
         wire_node = BNode()
         g.add((wiring_uri, GDS_CORE["hasWire"], wire_node))
         g.add((wire_node, RDF.type, GDS_CORE["Wire"]))
-        g.add((wire_node, GDS_CORE["source"], Literal(source_block)))
-        g.add((wire_node, GDS_CORE["target"], Literal(target_block)))
-        g.add((wire_node, GDS_CORE["optional"], Literal(False, datatype=XSD.boolean)))
+        g.add((wire_node, GDS_CORE["wireSource"], Literal(source_block)))
+        g.add((wire_node, GDS_CORE["wireTarget"], Literal(target_block)))
+        g.add(
+            (wire_node, GDS_CORE["wireOptional"], Literal(False, datatype=XSD.boolean))
+        )
 
     for name in block_names:
-        g.add((wiring_uri, GDS_CORE["blockName"], Literal(name)))
+        if name in block_uris:
+            g.add((wiring_uri, GDS_CORE["wiringBlock"], block_uris[name]))
 
     g.add((spec_uri, GDS_CORE["hasWiring"], wiring_uri))
 

--- a/packages/gds-sysml/gds_sysml/rdf.py
+++ b/packages/gds-sysml/gds_sysml/rdf.py
@@ -1,0 +1,557 @@
+"""SysML v2 model → RDF graph conversion via OSLC vocabulary.
+
+Converts a parsed SysMLModel into an rdflib.Graph using:
+1. OSLC SysML v2 vocabulary for SysML elements (PartDefinition, ActionUsage, etc.)
+2. GDS-core ontology for GDS-specific concepts (blocks, roles, entities, etc.)
+
+The graph can then be consumed by gds_owl.graph_to_spec() to produce a GDSSpec.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
+
+from gds_owl._namespace import DEFAULT_BASE_URI, GDS_CORE, PREFIXES
+from gds_sysml._namespace import GDS_SYSML, SYSML_OSLC
+
+if TYPE_CHECKING:
+    from gds_sysml.model import (
+        GDSAnnotation,
+        SysMLAttribute,
+        SysMLModel,
+    )
+
+# ── SysML type → Python type mapping ───────────────────────────
+
+_SYSML_TYPE_MAP: dict[str, str] = {
+    "Real": "float",
+    "Integer": "int",
+    "Boolean": "bool",
+    "String": "str",
+    "Natural": "int",
+    "Positive": "int",
+    "ScalarValues::Real": "float",
+    "ScalarValues::Integer": "int",
+    "ScalarValues::Boolean": "bool",
+    "ScalarValues::String": "str",
+}
+
+# ── SysML unit → GDS unit mapping ──────────────────────────────
+
+_UNIT_MAP: dict[str, str] = {
+    "K": "kelvin",
+    "kelvin": "kelvin",
+    "Kelvin": "kelvin",
+    "W": "watts",
+    "watts": "watts",
+    "Watts": "watts",
+    "kg": "kg",
+    "m": "meters",
+    "s": "seconds",
+    "A": "amperes",
+    "V": "volts",
+    "rad": "radians",
+    "deg": "degrees",
+    "rad/s": "rad/s",
+    "N": "newtons",
+    "Nm": "newton-meters",
+    "m/s": "m/s",
+    "m/s^2": "m/s^2",
+    "kg/m^2": "kg/m^2",
+    "": "",
+}
+
+
+def _bind(g: Graph) -> None:
+    """Bind standard prefixes to graph."""
+    for prefix, ns in PREFIXES.items():
+        g.bind(prefix, ns)
+    for prefix, ns in {
+        "gds-core": GDS_CORE,
+        "sysml": SYSML_OSLC,
+        "gds-sysml": GDS_SYSML,
+    }.items():
+        g.bind(prefix, ns)
+
+
+def _ns(base_uri: str, model_name: str) -> Namespace:
+    """Build an instance namespace for a SysML model."""
+    safe = quote(model_name or "sysml_model", safe="")
+    return Namespace(f"{base_uri}{safe}/")
+
+
+def _uri(ns: Namespace, category: str, name: str) -> URIRef:
+    """Build a deterministic instance URI."""
+    safe = quote(name, safe="")
+    return ns[f"{category}/{safe}"]
+
+
+def _get_gds_role(annotations: list[GDSAnnotation]) -> str:
+    """Determine GDS block role from @GDS* annotations.
+
+    Returns one of: "boundary", "policy", "mechanism", "control".
+    Defaults to "policy" if no role annotation found.
+    """
+    role_map = {
+        "BoundaryAction": "boundary",
+        "Boundary": "boundary",
+        "Policy": "policy",
+        "Mechanism": "mechanism",
+        "ControlAction": "control",
+        "Control": "control",
+    }
+    for ann in annotations:
+        if ann.kind in role_map:
+            return role_map[ann.kind]
+    return "policy"
+
+
+def _get_annotation(
+    annotations: list[GDSAnnotation], kind: str
+) -> GDSAnnotation | None:
+    """Find a specific annotation by kind."""
+    for ann in annotations:
+        if ann.kind == kind:
+            return ann
+    return None
+
+
+def _python_type_str(sysml_type: str) -> str:
+    """Map SysML type name to Python type string."""
+    return _SYSML_TYPE_MAP.get(sysml_type, "float")
+
+
+def _map_units(raw_units: str) -> str:
+    """Map SysML/user units to normalized GDS units."""
+    return _UNIT_MAP.get(raw_units, raw_units)
+
+
+# ── Main conversion ────────────────────────────────────────────
+
+
+def sysml_to_rdf(
+    model: SysMLModel,
+    *,
+    base_uri: str = DEFAULT_BASE_URI,
+) -> Graph:
+    """Convert a parsed SysMLModel to an RDF graph.
+
+    The output graph uses GDS-core ontology classes so it can be consumed
+    directly by ``gds_owl.graph_to_spec()``.
+
+    Args:
+        model: Parsed SysML v2 model from the parser layer.
+        base_uri: Base URI for instance data.
+
+    Returns:
+        An rdflib.Graph with GDS-core ontology triples.
+    """
+    g = Graph()
+    _bind(g)
+    ns = _ns(base_uri, model.name)
+
+    # Create spec individual
+    spec_uri = ns["spec"]
+    g.add((spec_uri, RDF.type, GDS_CORE["GDSSpec"]))
+    g.add((spec_uri, GDS_CORE["name"], Literal(model.name or "SysMLModel")))
+    g.add((spec_uri, GDS_CORE["description"], Literal("")))
+
+    # Track URIs for cross-referencing
+    type_uris: dict[str, URIRef] = {}
+    entity_uris: dict[str, URIRef] = {}
+    block_uris: dict[str, URIRef] = {}
+    param_uris: dict[str, URIRef] = {}
+
+    # 1. Extract TypeDefs from attributes with @GDSStateVariable or @GDSParameter
+    _emit_typedefs(g, ns, spec_uri, model, type_uris)
+
+    # 2. Extract Entities from parts with @GDS* state variable attributes
+    _emit_entities(g, ns, spec_uri, model, type_uris, entity_uris)
+
+    # 3. Extract Parameters from attributes with @GDSParameter
+    _emit_parameters(g, ns, spec_uri, model, type_uris, param_uris)
+
+    # 4. Extract Blocks from actions with @GDS* role annotations
+    _emit_blocks(g, ns, spec_uri, model, type_uris, entity_uris, param_uris, block_uris)
+
+    # 5. Extract Wirings from connections
+    _emit_wirings(g, ns, spec_uri, model, block_uris)
+
+    # 6. Extract TransitionSignatures from @GDSDynamics annotations
+    _emit_transition_signatures(g, ns, spec_uri, model, entity_uris)
+
+    return g
+
+
+# ── TypeDef emission ────────────────────────────────────────────
+
+
+def _emit_typedefs(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    type_uris: dict[str, URIRef],
+) -> None:
+    """Emit TypeDef triples from SysML attributes with type annotations."""
+    seen_types: set[str] = set()
+
+    for part in model.parts.values():
+        for attr in part.attributes:
+            _maybe_emit_typedef(g, ns, spec_uri, attr, type_uris, seen_types)
+
+    for action in model.actions.values():
+        for attr in action.attributes:
+            _maybe_emit_typedef(g, ns, spec_uri, attr, type_uris, seen_types)
+
+    # Also emit types referenced by ports
+    for action in model.actions.values():
+        for port in action.ports:
+            if port.type_name and port.type_name not in seen_types:
+                _emit_typedef_for_port(
+                    g, ns, spec_uri, port.type_name, type_uris, seen_types
+                )
+
+
+def _maybe_emit_typedef(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    attr: SysMLAttribute,
+    type_uris: dict[str, URIRef],
+    seen: set[str],
+) -> None:
+    """Emit a TypeDef if we haven't seen this type name yet."""
+    # Use the attribute's type_name as the TypeDef name
+    type_name = attr.type_name or attr.name
+    if type_name in seen:
+        return
+    seen.add(type_name)
+
+    uri = _uri(ns, "type", type_name)
+    type_uris[type_name] = uri
+
+    g.add((uri, RDF.type, GDS_CORE["TypeDef"]))
+    g.add((uri, GDS_CORE["name"], Literal(type_name)))
+    g.add((uri, GDS_CORE["description"], Literal("")))
+    g.add((uri, GDS_CORE["pythonType"], Literal(_python_type_str(attr.type_name))))
+    g.add((uri, GDS_CORE["hasConstraint"], Literal(False, datatype=XSD.boolean)))
+
+    # Check for units from @GDS* annotations
+    for ann in attr.annotations:
+        units = ann.properties.get("units", "")
+        if isinstance(units, str) and units:
+            g.add((uri, GDS_CORE["units"], Literal(_map_units(units))))
+
+    g.add((spec_uri, GDS_CORE["hasType"], uri))
+
+
+def _emit_typedef_for_port(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    type_name: str,
+    type_uris: dict[str, URIRef],
+    seen: set[str],
+) -> None:
+    """Emit a TypeDef for a port type reference."""
+    seen.add(type_name)
+    uri = _uri(ns, "type", type_name)
+    type_uris[type_name] = uri
+
+    g.add((uri, RDF.type, GDS_CORE["TypeDef"]))
+    g.add((uri, GDS_CORE["name"], Literal(type_name)))
+    g.add((uri, GDS_CORE["description"], Literal("")))
+    g.add((uri, GDS_CORE["pythonType"], Literal("float")))
+    g.add((uri, GDS_CORE["hasConstraint"], Literal(False, datatype=XSD.boolean)))
+    g.add((spec_uri, GDS_CORE["hasType"], uri))
+
+
+# ── Entity emission ─────────────────────────────────────────────
+
+
+def _emit_entities(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    type_uris: dict[str, URIRef],
+    entity_uris: dict[str, URIRef],
+) -> None:
+    """Emit Entity triples from SysML parts with @GDSStateVariable attributes."""
+    for part in model.parts.values():
+        state_vars = [
+            attr
+            for attr in part.attributes
+            if _get_annotation(attr.annotations, "StateVariable") is not None
+        ]
+        if not state_vars:
+            continue
+
+        entity_uri = _uri(ns, "entity", part.name)
+        entity_uris[part.name] = entity_uri
+
+        g.add((entity_uri, RDF.type, GDS_CORE["Entity"]))
+        g.add((entity_uri, GDS_CORE["name"], Literal(part.name)))
+        g.add((entity_uri, GDS_CORE["description"], Literal("")))
+
+        for attr in state_vars:
+            var_uri = _uri(ns, f"entity/{quote(part.name, safe='')}/var", attr.name)
+            g.add((entity_uri, GDS_CORE["hasVariable"], var_uri))
+            g.add((var_uri, RDF.type, GDS_CORE["StateVariable"]))
+            g.add((var_uri, GDS_CORE["name"], Literal(attr.name)))
+            g.add((var_uri, GDS_CORE["description"], Literal("")))
+
+            # Symbol from annotation properties
+            sv_ann = _get_annotation(attr.annotations, "StateVariable")
+            symbol = ""
+            if sv_ann:
+                sym = sv_ann.properties.get("symbol", "")
+                if isinstance(sym, str):
+                    symbol = sym
+            g.add((var_uri, GDS_CORE["symbol"], Literal(symbol)))
+
+            # Type reference
+            type_name = attr.type_name or attr.name
+            if type_name in type_uris:
+                g.add((var_uri, GDS_CORE["usesType"], type_uris[type_name]))
+
+        g.add((spec_uri, GDS_CORE["hasEntity"], entity_uri))
+
+
+# ── Parameter emission ──────────────────────────────────────────
+
+
+def _emit_parameters(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    type_uris: dict[str, URIRef],
+    param_uris: dict[str, URIRef],
+) -> None:
+    """Emit ParameterDef triples from attributes with @GDSParameter."""
+    seen: set[str] = set()
+
+    for part in model.parts.values():
+        for attr in part.attributes:
+            if _get_annotation(attr.annotations, "Parameter") is None:
+                continue
+            if attr.name in seen:
+                continue
+            seen.add(attr.name)
+
+            param_uri = _uri(ns, "parameter", attr.name)
+            param_uris[attr.name] = param_uri
+
+            g.add((param_uri, RDF.type, GDS_CORE["ParameterDef"]))
+            g.add((param_uri, GDS_CORE["name"], Literal(attr.name)))
+            g.add((param_uri, GDS_CORE["description"], Literal("")))
+
+            type_name = attr.type_name or attr.name
+            if type_name in type_uris:
+                g.add((param_uri, GDS_CORE["hasTypeDef"], type_uris[type_name]))
+
+            g.add((spec_uri, GDS_CORE["hasParameter"], param_uri))
+
+
+# ── Block emission ──────────────────────────────────────────────
+
+
+def _emit_blocks(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    type_uris: dict[str, URIRef],
+    entity_uris: dict[str, URIRef],
+    param_uris: dict[str, URIRef],
+    block_uris: dict[str, URIRef],
+) -> None:
+    """Emit Block triples from SysML actions with @GDS* role annotations."""
+    for action in model.actions.values():
+        role = _get_gds_role(action.annotations)
+        block_uri = _uri(ns, "block", action.name)
+        block_uris[action.name] = block_uri
+
+        # Map role to RDF class
+        role_class = {
+            "boundary": "BoundaryAction",
+            "policy": "Policy",
+            "mechanism": "Mechanism",
+            "control": "ControlAction",
+        }.get(role, "AtomicBlock")
+
+        g.add((block_uri, RDF.type, GDS_CORE[role_class]))
+        g.add((block_uri, GDS_CORE["name"], Literal(action.name)))
+        g.add((block_uri, GDS_CORE["kind"], Literal(role)))
+
+        # Build interface from ports
+        iface_node = BNode()
+        g.add((block_uri, GDS_CORE["hasInterface"], iface_node))
+        g.add((iface_node, RDF.type, GDS_CORE["Interface"]))
+
+        for port in action.ports:
+            port_node = BNode()
+            g.add((port_node, RDF.type, GDS_CORE["Port"]))
+            port_label = port.type_name or port.name
+            g.add((port_node, GDS_CORE["portName"], Literal(port_label)))
+
+            if port.direction == "in":
+                g.add((iface_node, GDS_CORE["hasForwardIn"], port_node))
+            elif port.direction == "out":
+                g.add((iface_node, GDS_CORE["hasForwardOut"], port_node))
+            else:
+                # Default: use port name heuristics
+                if "out" in port.name.lower() or "emit" in port.name.lower():
+                    g.add((iface_node, GDS_CORE["hasForwardOut"], port_node))
+                else:
+                    g.add((iface_node, GDS_CORE["hasForwardIn"], port_node))
+
+        # For mechanisms: emit update map from @GDSDynamics
+        if role == "mechanism":
+            dynamics = _get_annotation(action.annotations, "Dynamics")
+            if dynamics:
+                writes = dynamics.properties.get("writes", [])
+                if isinstance(writes, list):
+                    for write_ref in writes:
+                        _emit_update_entry(g, block_uri, write_ref, model, entity_uris)
+
+        # Parameter references from @GDS* annotations
+        for ann in action.annotations:
+            params_used = ann.properties.get("params", [])
+            if isinstance(params_used, list):
+                for p in params_used:
+                    g.add((block_uri, GDS_CORE["paramUsed"], Literal(p)))
+
+        g.add((spec_uri, GDS_CORE["hasBlock"], block_uri))
+
+
+def _emit_update_entry(
+    g: Graph,
+    block_uri: URIRef,
+    write_ref: str,
+    model: SysMLModel,
+    entity_uris: dict[str, URIRef],
+) -> None:
+    """Emit an UpdateMapEntry for a mechanism's write target.
+
+    The write_ref can be "entity.variable" or just "variable" (resolved
+    by searching all entities).
+    """
+    if "." in write_ref:
+        entity_name, var_name = write_ref.split(".", 1)
+    else:
+        # Search for the variable across all entities
+        entity_name = ""
+        var_name = write_ref
+        for part in model.parts.values():
+            for attr in part.attributes:
+                if attr.name == write_ref:
+                    entity_name = part.name
+                    break
+            if entity_name:
+                break
+
+    if entity_name:
+        entry = BNode()
+        g.add((block_uri, GDS_CORE["updatesEntry"], entry))
+        g.add((entry, RDF.type, GDS_CORE["UpdateMapEntry"]))
+        g.add((entry, GDS_CORE["updatesEntity"], Literal(entity_name)))
+        g.add((entry, GDS_CORE["updatesVariable"], Literal(var_name)))
+
+
+# ── Wiring emission ─────────────────────────────────────────────
+
+
+def _emit_wirings(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    block_uris: dict[str, URIRef],
+) -> None:
+    """Emit SpecWiring triples from SysML connections."""
+    if not model.connections:
+        return
+
+    wiring_uri = _uri(ns, "wiring", "main")
+    g.add((wiring_uri, RDF.type, GDS_CORE["SpecWiring"]))
+    g.add((wiring_uri, GDS_CORE["name"], Literal("main")))
+    g.add((wiring_uri, GDS_CORE["description"], Literal("")))
+
+    # Collect all referenced block names
+    block_names: set[str] = set()
+
+    for conn in model.connections:
+        source_block = conn.source.split(".")[0]
+        target_block = conn.target.split(".")[0]
+        block_names.add(source_block)
+        block_names.add(target_block)
+
+        wire_node = BNode()
+        g.add((wiring_uri, GDS_CORE["hasWire"], wire_node))
+        g.add((wire_node, RDF.type, GDS_CORE["Wire"]))
+        g.add((wire_node, GDS_CORE["source"], Literal(source_block)))
+        g.add((wire_node, GDS_CORE["target"], Literal(target_block)))
+        g.add((wire_node, GDS_CORE["optional"], Literal(False, datatype=XSD.boolean)))
+
+    for name in block_names:
+        g.add((wiring_uri, GDS_CORE["blockName"], Literal(name)))
+
+    g.add((spec_uri, GDS_CORE["hasWiring"], wiring_uri))
+
+
+# ── Transition signature emission ───────────────────────────────
+
+
+def _emit_transition_signatures(
+    g: Graph,
+    ns: Namespace,
+    spec_uri: URIRef,
+    model: SysMLModel,
+    entity_uris: dict[str, URIRef],
+) -> None:
+    """Emit TransitionSignature triples from @GDSDynamics annotations."""
+    for action in model.actions.values():
+        dynamics = _get_annotation(action.annotations, "Dynamics")
+        if not dynamics:
+            continue
+
+        reads = dynamics.properties.get("reads", [])
+        if not isinstance(reads, list) or not reads:
+            continue
+
+        ts_uri = _uri(ns, "transition", action.name)
+        g.add((ts_uri, RDF.type, GDS_CORE["TransitionSignature"]))
+        g.add((ts_uri, GDS_CORE["name"], Literal(action.name)))
+        g.add((ts_uri, GDS_CORE["signatureMechanism"], Literal(action.name)))
+        g.add((ts_uri, GDS_CORE["preservesInvariant"], Literal("")))
+
+        for read_ref in reads:
+            if "." in read_ref:
+                entity_name, var_name = read_ref.split(".", 1)
+            else:
+                entity_name = _find_entity_for_var(read_ref, model)
+                var_name = read_ref
+
+            if entity_name:
+                entry = BNode()
+                g.add((ts_uri, GDS_CORE["hasReadEntry"], entry))
+                g.add((entry, RDF.type, GDS_CORE["TransitionReadEntry"]))
+                g.add((entry, GDS_CORE["readEntity"], Literal(entity_name)))
+                g.add((entry, GDS_CORE["readVariable"], Literal(var_name)))
+
+        g.add((spec_uri, GDS_CORE["hasTransitionSignature"], ts_uri))
+
+
+def _find_entity_for_var(var_name: str, model: SysMLModel) -> str:
+    """Search model parts for the entity containing a state variable."""
+    for part in model.parts.values():
+        for attr in part.attributes:
+            if attr.name == var_name:
+                return part.name
+    return ""

--- a/packages/gds-sysml/pyproject.toml
+++ b/packages/gds-sysml/pyproject.toml
@@ -1,0 +1,85 @@
+[project]
+name = "gds-sysml"
+dynamic = ["version"]
+description = "SysML v2 bridge for gds-framework via OSLC RDF vocabulary"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.12"
+authors = [
+    { name = "Rohan Mehta", email = "rohan@block.science" },
+]
+keywords = [
+    "generalized-dynamical-systems",
+    "sysml",
+    "sysml-v2",
+    "oslc",
+    "rdf",
+    "model-interchange",
+    "gds-framework",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "gds-framework>=0.3.0",
+    "gds-owl>=0.2.0",
+    "rdflib>=7.0",
+]
+
+[project.optional-dependencies]
+syson = [
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/BlockScience/gds-core"
+Repository = "https://github.com/BlockScience/gds-core"
+Documentation = "https://blockscience.github.io/gds-core"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "gds_sysml/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["gds_sysml"]
+
+[tool.uv.sources]
+gds-framework = { workspace = true }
+gds-owl = { workspace = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--import-mode=importlib --cov=gds_sysml --cov-report=term-missing --no-header -q"
+
+[tool.coverage.run]
+source = ["gds_sysml"]
+omit = ["gds_sysml/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.19.1",
+    "pyright>=1.1.408",
+    "pytest>=8.0",
+    "pytest-cov>=6.0",
+    "ruff>=0.8",
+]

--- a/packages/gds-sysml/tests/conftest.py
+++ b/packages/gds-sysml/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared test fixtures for gds-sysml."""
+
+from pathlib import Path
+
+import pytest
+from gds_sysml.model import SysMLModel
+from gds_sysml.parser.regex import parse_sysml
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def satellite_sysml_path() -> Path:
+    """Path to the simple satellite .sysml fixture."""
+    return FIXTURES_DIR / "simple_satellite.sysml"
+
+
+@pytest.fixture()
+def satellite_sysml_text(satellite_sysml_path: Path) -> str:
+    """Raw text of the simple satellite .sysml fixture."""
+    return satellite_sysml_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def satellite_model(satellite_sysml_path: Path) -> SysMLModel:
+    """Parsed SysMLModel from the simple satellite fixture."""
+    return parse_sysml(satellite_sysml_path)

--- a/packages/gds-sysml/tests/conftest.py
+++ b/packages/gds-sysml/tests/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+
 from gds_sysml.model import SysMLModel
 from gds_sysml.parser.regex import parse_sysml
 

--- a/packages/gds-sysml/tests/fixtures/simple_satellite.sysml
+++ b/packages/gds-sysml/tests/fixtures/simple_satellite.sysml
@@ -1,0 +1,94 @@
+/* Simple Satellite Thermal Control System
+ *
+ * A minimal SysML v2 model with @GDS* annotations demonstrating
+ * the SysML→GDS pipeline. Models a satellite's thermal control
+ * loop with sensors, controllers, and actuators.
+ *
+ * GDS decomposition:
+ *   BoundaryAction: SolarFluxSensor, TemperatureSensor
+ *   Policy: ThermalController
+ *   Mechanism: HeaterActuator, RadiatorActuator
+ *   Entities: ThermalState (temperature, heaterPower, radiatorAngle)
+ */
+
+package SimpleSatellite {
+
+    // ── GDS metadata definitions ──────────────────────────────
+
+    metadata def GDSBoundaryAction;
+    metadata def GDSPolicy;
+    metadata def GDSMechanism;
+    metadata def GDSControlAction;
+    metadata def GDSStateVariable;
+    metadata def GDSParameter;
+    metadata def GDSDynamics;
+
+    // ── Type definitions ──────────────────────────────────────
+
+    part def Temperature;
+    part def Power;
+    part def Angle;
+    part def HeatFlux;
+
+    // ── State entity ──────────────────────────────────────────
+
+    part def ThermalState {
+        @GDSStateVariable { symbol = "T"; }
+        attribute temperature : Real;
+
+        @GDSStateVariable { symbol = "P_h"; }
+        attribute heaterPower : Real;
+
+        @GDSStateVariable { symbol = "alpha"; }
+        attribute radiatorAngle : Real;
+
+        @GDSParameter { units = "W/m^2"; }
+        attribute solarConstant : Real;
+
+        @GDSParameter { units = "kg/m^2"; }
+        attribute thermalMass : Real;
+    }
+
+    // ── Boundary actions (exogenous inputs) ───────────────────
+
+    @GDSBoundaryAction
+    action def SolarFluxSensor {
+        out port solarFluxOut : HeatFlux;
+    }
+
+    @GDSBoundaryAction
+    action def TemperatureSensor {
+        out port temperatureOut : Temperature;
+    }
+
+    // ── Policy (decision logic) ───────────────────────────────
+
+    @GDSPolicy
+    action def ThermalController {
+        in port temperatureIn : Temperature;
+        in port solarFluxIn : HeatFlux;
+        out port heaterCommandOut : Power;
+        out port radiatorCommandOut : Angle;
+    }
+
+    // ── Mechanisms (state updates) ────────────────────────────
+
+    @GDSMechanism
+    @GDSDynamics { reads = [temperature, heaterPower]; writes = [temperature]; }
+    action def HeaterActuator {
+        in port heaterCommandIn : Power;
+    }
+
+    @GDSMechanism
+    @GDSDynamics { reads = [temperature, radiatorAngle]; writes = [radiatorAngle]; }
+    action def RadiatorActuator {
+        in port radiatorCommandIn : Angle;
+    }
+
+    // ── Connections (wiring) ──────────────────────────────────
+
+    connect SolarFluxSensor.solarFluxOut to ThermalController.solarFluxIn;
+    connect TemperatureSensor.temperatureOut to ThermalController.temperatureIn;
+    connect ThermalController.heaterCommandOut to HeaterActuator.heaterCommandIn;
+    connect ThermalController.radiatorCommandOut to RadiatorActuator.radiatorCommandIn;
+}

--- a/packages/gds-sysml/tests/test_import.py
+++ b/packages/gds-sysml/tests/test_import.py
@@ -1,0 +1,133 @@
+"""Tests for the end-to-end SysML → GDSSpec import pipeline."""
+
+from pathlib import Path
+
+from gds_sysml.import_ import sysml_to_spec
+from gds_sysml.model import SysMLModel
+
+
+class TestSysMLToSpec:
+    """End-to-end tests for sysml_to_spec()."""
+
+    def test_spec_name(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        assert spec.name == "SimpleSatellite"
+
+    def test_spec_from_path(self, satellite_sysml_path: Path) -> None:
+        spec = sysml_to_spec(satellite_sysml_path)
+        assert spec.name == "SimpleSatellite"
+
+    def test_spec_from_text(self, satellite_sysml_text: str) -> None:
+        spec = sysml_to_spec(satellite_sysml_text)
+        assert spec.name == "SimpleSatellite"
+
+    def test_blocks_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        block_names = set(spec.blocks.keys())
+        expected = {
+            "SolarFluxSensor",
+            "TemperatureSensor",
+            "ThermalController",
+            "HeaterActuator",
+            "RadiatorActuator",
+        }
+        assert expected == block_names
+
+    def test_block_roles(self, satellite_model: SysMLModel) -> None:
+        from gds.blocks.roles import BoundaryAction, Mechanism, Policy
+
+        spec = sysml_to_spec(satellite_model)
+        assert isinstance(spec.blocks["SolarFluxSensor"], BoundaryAction)
+        assert isinstance(spec.blocks["TemperatureSensor"], BoundaryAction)
+        assert isinstance(spec.blocks["ThermalController"], Policy)
+        assert isinstance(spec.blocks["HeaterActuator"], Mechanism)
+        assert isinstance(spec.blocks["RadiatorActuator"], Mechanism)
+
+    def test_entities_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        assert "ThermalState" in spec.entities
+        entity = spec.entities["ThermalState"]
+        var_names = set(entity.variables.keys())
+        assert "temperature" in var_names
+        assert "heaterPower" in var_names
+        assert "radiatorAngle" in var_names
+
+    def test_state_variable_symbols(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        entity = spec.entities["ThermalState"]
+        assert entity.variables["temperature"].symbol == "T"
+        assert entity.variables["heaterPower"].symbol == "P_h"
+        assert entity.variables["radiatorAngle"].symbol == "alpha"
+
+    def test_types_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        assert len(spec.types) > 0
+        # Real should map to a float TypeDef
+        type_names = set(spec.types.keys())
+        assert "Real" in type_names
+
+    def test_parameters_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        param_names = set(spec.parameter_schema.parameters.keys())
+        assert "solarConstant" in param_names
+        assert "thermalMass" in param_names
+
+    def test_wirings_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        assert len(spec.wirings) > 0
+        wiring = next(iter(spec.wirings.values()))
+        assert len(wiring.wires) == 4
+
+    def test_transition_signatures_imported(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        assert len(spec.transition_signatures) == 2
+        ts_names = {ts.mechanism for ts in spec.transition_signatures.values()}
+        assert "HeaterActuator" in ts_names
+        assert "RadiatorActuator" in ts_names
+
+    def test_mechanism_updates(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        heater = spec.blocks["HeaterActuator"]
+        assert hasattr(heater, "updates")
+        # Should have update entries for temperature
+        assert len(heater.updates) > 0
+
+
+class TestMinimalImport:
+    """Tests for importing minimal SysML models."""
+
+    def test_empty_model(self) -> None:
+        model = SysMLModel(name="Empty")
+        spec = sysml_to_spec(model)
+        assert spec.name == "Empty"
+        assert len(spec.blocks) == 0
+
+    def test_single_boundary_action(self) -> None:
+        sysml = """
+        package Test {
+            @GDSBoundaryAction
+            action def Sensor {
+                out port dataOut : Signal;
+            }
+        }
+        """
+        spec = sysml_to_spec(sysml)
+        assert "Sensor" in spec.blocks
+        from gds.blocks.roles import BoundaryAction
+
+        assert isinstance(spec.blocks["Sensor"], BoundaryAction)
+
+    def test_policy_with_ports(self) -> None:
+        sysml = """
+        package Test {
+            @GDSPolicy
+            action def Controller {
+                in port sensorIn : Data;
+                out port commandOut : Command;
+            }
+        }
+        """
+        spec = sysml_to_spec(sysml)
+        controller = spec.blocks["Controller"]
+        assert len(controller.interface.forward_in) > 0
+        assert len(controller.interface.forward_out) > 0

--- a/packages/gds-sysml/tests/test_import.py
+++ b/packages/gds-sysml/tests/test_import.py
@@ -77,6 +77,24 @@ class TestSysMLToSpec:
         assert len(spec.wirings) > 0
         wiring = next(iter(spec.wirings.values()))
         assert len(wiring.wires) == 4
+        # Verify wire content survives round-trip (not just count)
+        wire_pairs = {(w.source, w.target) for w in wiring.wires}
+        assert ("SolarFluxSensor", "ThermalController") in wire_pairs
+        assert ("TemperatureSensor", "ThermalController") in wire_pairs
+        assert ("ThermalController", "HeaterActuator") in wire_pairs
+        assert ("ThermalController", "RadiatorActuator") in wire_pairs
+
+    def test_wiring_block_names(self, satellite_model: SysMLModel) -> None:
+        spec = sysml_to_spec(satellite_model)
+        wiring = next(iter(spec.wirings.values()))
+        expected_blocks = {
+            "SolarFluxSensor",
+            "TemperatureSensor",
+            "ThermalController",
+            "HeaterActuator",
+            "RadiatorActuator",
+        }
+        assert set(wiring.block_names) == expected_blocks
 
     def test_transition_signatures_imported(self, satellite_model: SysMLModel) -> None:
         spec = sysml_to_spec(satellite_model)
@@ -91,6 +109,48 @@ class TestSysMLToSpec:
         assert hasattr(heater, "updates")
         # Should have update entries for temperature
         assert len(heater.updates) > 0
+
+
+class TestMultilineAnnotations:
+    """Tests for multi-line @GDS* annotation body parsing."""
+
+    def test_multiline_annotation_body(self) -> None:
+        sysml = """
+        package Test {
+            part def State {
+                @GDSStateVariable {
+                    symbol = "T";
+                    units = "K";
+                }
+                attribute temperature : Real;
+            }
+        }
+        """
+        spec = sysml_to_spec(sysml)
+        assert "State" in spec.entities
+        entity = spec.entities["State"]
+        assert "temperature" in entity.variables
+        assert entity.variables["temperature"].symbol == "T"
+
+    def test_multiline_dynamics(self) -> None:
+        sysml = """
+        package Test {
+            part def State {
+                @GDSStateVariable { symbol = "x"; }
+                attribute x : Real;
+            }
+            @GDSMechanism
+            @GDSDynamics {
+                reads = [x];
+                writes = [x];
+            }
+            action def Updater {
+                in port input : Real;
+            }
+        }
+        """
+        spec = sysml_to_spec(sysml)
+        assert "Updater" in spec.blocks
 
 
 class TestMinimalImport:

--- a/packages/gds-sysml/tests/test_parser.py
+++ b/packages/gds-sysml/tests/test_parser.py
@@ -1,0 +1,257 @@
+"""Tests for the regex-based SysML v2 parser."""
+
+from pathlib import Path
+
+from gds_sysml.model import SysMLModel
+from gds_sysml.parser.regex import (
+    _extract_annotations,
+    _parse_annotation_body,
+    _strip_comments,
+    parse_sysml,
+)
+
+
+class TestAnnotationParsing:
+    """Tests for @GDS* annotation extraction."""
+
+    def test_simple_annotation(self) -> None:
+        anns = _extract_annotations("@GDSMechanism")
+        assert len(anns) == 1
+        assert anns[0].kind == "Mechanism"
+        assert anns[0].properties == {}
+
+    def test_annotation_with_body(self) -> None:
+        anns = _extract_annotations("@GDSDynamics { reads = [x, y]; writes = [z]; }")
+        assert len(anns) == 1
+        assert anns[0].kind == "Dynamics"
+        assert anns[0].properties["reads"] == ["x", "y"]
+        assert anns[0].properties["writes"] == ["z"]
+
+    def test_annotation_with_string_property(self) -> None:
+        anns = _extract_annotations('@GDSStateVariable { symbol = "T"; }')
+        assert len(anns) == 1
+        assert anns[0].properties["symbol"] == "T"
+
+    def test_annotation_with_bare_value(self) -> None:
+        anns = _extract_annotations("@GDSParameter { units = kelvin; }")
+        assert len(anns) == 1
+        assert anns[0].properties["units"] == "kelvin"
+
+    def test_multiple_annotations_on_line(self) -> None:
+        anns = _extract_annotations(
+            "@GDSMechanism @GDSDynamics { reads = [x]; writes = [y]; }"
+        )
+        assert len(anns) == 2
+        assert anns[0].kind == "Mechanism"
+        assert anns[1].kind == "Dynamics"
+
+    def test_boundary_action_annotation(self) -> None:
+        anns = _extract_annotations("@GDSBoundaryAction")
+        assert len(anns) == 1
+        assert anns[0].kind == "BoundaryAction"
+
+    def test_no_annotations(self) -> None:
+        anns = _extract_annotations("part def Foo {")
+        assert len(anns) == 0
+
+
+class TestAnnotationBody:
+    """Tests for annotation body property parsing."""
+
+    def test_empty_body(self) -> None:
+        assert _parse_annotation_body("") == {}
+
+    def test_list_value(self) -> None:
+        props = _parse_annotation_body("reads = [a, b, c];")
+        assert props["reads"] == ["a", "b", "c"]
+
+    def test_quoted_string(self) -> None:
+        props = _parse_annotation_body('symbol = "alpha";')
+        assert props["symbol"] == "alpha"
+
+    def test_bare_value(self) -> None:
+        props = _parse_annotation_body("units = watts;")
+        assert props["units"] == "watts"
+
+    def test_multiple_properties(self) -> None:
+        props = _parse_annotation_body('reads = [x, y]; writes = [z]; symbol = "f";')
+        assert props["reads"] == ["x", "y"]
+        assert props["writes"] == ["z"]
+        assert props["symbol"] == "f"
+
+
+class TestCommentStripping:
+    """Tests for comment removal."""
+
+    def test_line_comment(self) -> None:
+        lines = _strip_comments("part def Foo { // this is a comment")
+        assert lines[0] == "part def Foo { "
+
+    def test_block_comment(self) -> None:
+        lines = _strip_comments("/* block comment */\npart def Foo {")
+        assert "block comment" not in lines[0]
+        assert "part def Foo" in lines[1]
+
+    def test_multiline_block_comment(self) -> None:
+        text = "before\n/* start\nmiddle\nend */\nafter"
+        lines = _strip_comments(text)
+        joined = " ".join(lines)
+        assert "middle" not in joined
+        assert "before" in joined
+        assert "after" in joined
+
+
+class TestParserSatellite:
+    """Tests for parsing the simple satellite fixture."""
+
+    def test_model_name(self, satellite_model: SysMLModel) -> None:
+        assert satellite_model.name == "SimpleSatellite"
+
+    def test_metadata_defs(self, satellite_model: SysMLModel) -> None:
+        assert "GDSBoundaryAction" in satellite_model.metadata_defs
+        assert "GDSPolicy" in satellite_model.metadata_defs
+        assert "GDSMechanism" in satellite_model.metadata_defs
+        assert "GDSStateVariable" in satellite_model.metadata_defs
+        assert "GDSParameter" in satellite_model.metadata_defs
+        assert "GDSDynamics" in satellite_model.metadata_defs
+
+    def test_parts_found(self, satellite_model: SysMLModel) -> None:
+        assert "ThermalState" in satellite_model.parts
+
+    def test_thermal_state_attributes(self, satellite_model: SysMLModel) -> None:
+        thermal = satellite_model.parts["ThermalState"]
+        attr_names = [a.name for a in thermal.attributes]
+        assert "temperature" in attr_names
+        assert "heaterPower" in attr_names
+        assert "radiatorAngle" in attr_names
+        assert "solarConstant" in attr_names
+        assert "thermalMass" in attr_names
+
+    def test_state_variable_annotations(self, satellite_model: SysMLModel) -> None:
+        thermal = satellite_model.parts["ThermalState"]
+        temp_attr = next(a for a in thermal.attributes if a.name == "temperature")
+        assert any(ann.kind == "StateVariable" for ann in temp_attr.annotations)
+        sv_ann = next(
+            ann for ann in temp_attr.annotations if ann.kind == "StateVariable"
+        )
+        assert sv_ann.properties.get("symbol") == "T"
+
+    def test_parameter_annotations(self, satellite_model: SysMLModel) -> None:
+        thermal = satellite_model.parts["ThermalState"]
+        solar = next(a for a in thermal.attributes if a.name == "solarConstant")
+        assert any(ann.kind == "Parameter" for ann in solar.annotations)
+
+    def test_actions_found(self, satellite_model: SysMLModel) -> None:
+        expected_actions = {
+            "SolarFluxSensor",
+            "TemperatureSensor",
+            "ThermalController",
+            "HeaterActuator",
+            "RadiatorActuator",
+        }
+        assert expected_actions == set(satellite_model.actions.keys())
+
+    def test_boundary_action_role(self, satellite_model: SysMLModel) -> None:
+        sensor = satellite_model.actions["SolarFluxSensor"]
+        assert any(ann.kind == "BoundaryAction" for ann in sensor.annotations)
+
+    def test_mechanism_role(self, satellite_model: SysMLModel) -> None:
+        heater = satellite_model.actions["HeaterActuator"]
+        assert any(ann.kind == "Mechanism" for ann in heater.annotations)
+
+    def test_dynamics_annotation(self, satellite_model: SysMLModel) -> None:
+        heater = satellite_model.actions["HeaterActuator"]
+        dynamics = next(
+            (ann for ann in heater.annotations if ann.kind == "Dynamics"), None
+        )
+        assert dynamics is not None
+        assert dynamics.properties["reads"] == ["temperature", "heaterPower"]
+        assert dynamics.properties["writes"] == ["temperature"]
+
+    def test_action_ports(self, satellite_model: SysMLModel) -> None:
+        controller = satellite_model.actions["ThermalController"]
+        port_names = [p.name for p in controller.ports]
+        assert "temperatureIn" in port_names
+        assert "solarFluxIn" in port_names
+        assert "heaterCommandOut" in port_names
+        assert "radiatorCommandOut" in port_names
+
+    def test_port_directions(self, satellite_model: SysMLModel) -> None:
+        controller = satellite_model.actions["ThermalController"]
+        temp_port = next(p for p in controller.ports if p.name == "temperatureIn")
+        assert temp_port.direction == "in"
+        heater_port = next(p for p in controller.ports if p.name == "heaterCommandOut")
+        assert heater_port.direction == "out"
+
+    def test_connections_found(self, satellite_model: SysMLModel) -> None:
+        assert len(satellite_model.connections) == 4
+
+    def test_connection_endpoints(self, satellite_model: SysMLModel) -> None:
+        sources = {c.source for c in satellite_model.connections}
+        targets = {c.target for c in satellite_model.connections}
+        assert "SolarFluxSensor.solarFluxOut" in sources
+        assert "ThermalController.solarFluxIn" in targets
+
+    def test_parse_from_path(self, satellite_sysml_path: Path) -> None:
+        model = parse_sysml(satellite_sysml_path)
+        assert model.name == "SimpleSatellite"
+        assert len(model.actions) == 5
+
+    def test_parse_from_text(self, satellite_sysml_text: str) -> None:
+        model = parse_sysml(satellite_sysml_text)
+        assert model.name == "SimpleSatellite"
+        assert len(model.actions) == 5
+
+
+class TestParserMinimal:
+    """Tests for parsing minimal SysML fragments."""
+
+    def test_empty_package(self) -> None:
+        model = parse_sysml("package Empty { }")
+        assert model.name == "Empty"
+        assert len(model.parts) == 0
+        assert len(model.actions) == 0
+
+    def test_single_action(self) -> None:
+        sysml = """
+        package Test {
+            @GDSPolicy
+            action def MyPolicy {
+                in port inputPort : Signal;
+                out port outputPort : Command;
+            }
+        }
+        """
+        model = parse_sysml(sysml)
+        assert "MyPolicy" in model.actions
+        policy = model.actions["MyPolicy"]
+        assert any(ann.kind == "Policy" for ann in policy.annotations)
+        assert len(policy.ports) == 2
+
+    def test_single_part_with_state_var(self) -> None:
+        sysml = """
+        package Test {
+            part def MyEntity {
+                @GDSStateVariable { symbol = "x"; }
+                attribute position : Real;
+            }
+        }
+        """
+        model = parse_sysml(sysml)
+        assert "MyEntity" in model.parts
+        entity = model.parts["MyEntity"]
+        assert len(entity.attributes) == 1
+        assert entity.attributes[0].name == "position"
+        assert entity.attributes[0].type_name == "Real"
+
+    def test_connection_parsing(self) -> None:
+        sysml = """
+        package Test {
+            connect A.out to B.in;
+            connect B.out to C.in;
+        }
+        """
+        model = parse_sysml(sysml)
+        assert len(model.connections) == 2
+        assert model.connections[0].source == "A.out"
+        assert model.connections[0].target == "B.in"

--- a/packages/gds-sysml/tests/test_rdf.py
+++ b/packages/gds-sysml/tests/test_rdf.py
@@ -1,0 +1,115 @@
+"""Tests for SysML model → RDF conversion."""
+
+from gds_sysml.model import SysMLModel
+from gds_sysml.rdf import sysml_to_rdf
+from rdflib import RDF
+
+from gds_owl._namespace import GDS_CORE
+
+
+class TestRDFConversion:
+    """Tests for sysml_to_rdf() on the satellite fixture."""
+
+    def test_graph_not_empty(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        assert len(g) > 0
+
+    def test_spec_individual_exists(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        specs = list(g.subjects(RDF.type, GDS_CORE["GDSSpec"]))
+        assert len(specs) == 1
+
+    def test_spec_name(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        spec = next(g.subjects(RDF.type, GDS_CORE["GDSSpec"]))
+        name = str(next(g.objects(spec, GDS_CORE["name"])))
+        assert name == "SimpleSatellite"
+
+    def test_typedefs_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        typedefs = list(g.subjects(RDF.type, GDS_CORE["TypeDef"]))
+        assert len(typedefs) >= 3  # At least Real + port types
+
+    def test_entity_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        entities = list(g.subjects(RDF.type, GDS_CORE["Entity"]))
+        assert len(entities) == 1
+        name = str(next(g.objects(entities[0], GDS_CORE["name"])))
+        assert name == "ThermalState"
+
+    def test_state_variables_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        state_vars = list(g.subjects(RDF.type, GDS_CORE["StateVariable"]))
+        assert len(state_vars) == 3  # temperature, heaterPower, radiatorAngle
+
+    def test_parameters_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        params = list(g.subjects(RDF.type, GDS_CORE["ParameterDef"]))
+        assert len(params) == 2  # solarConstant, thermalMass
+
+    def test_blocks_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        # Count blocks by role
+        boundaries = list(g.subjects(RDF.type, GDS_CORE["BoundaryAction"]))
+        policies = list(g.subjects(RDF.type, GDS_CORE["Policy"]))
+        mechanisms = list(g.subjects(RDF.type, GDS_CORE["Mechanism"]))
+        assert len(boundaries) == 2  # SolarFluxSensor, TemperatureSensor
+        assert len(policies) == 1  # ThermalController
+        assert len(mechanisms) == 2  # HeaterActuator, RadiatorActuator
+
+    def test_block_interfaces(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        interfaces = list(g.subjects(RDF.type, GDS_CORE["Interface"]))
+        assert len(interfaces) == 5  # One per action
+
+    def test_wiring_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        wirings = list(g.subjects(RDF.type, GDS_CORE["SpecWiring"]))
+        assert len(wirings) == 1
+
+    def test_wires_emitted(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        wires = list(g.subjects(RDF.type, GDS_CORE["Wire"]))
+        assert len(wires) == 4
+
+    def test_transition_signatures(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        sigs = list(g.subjects(RDF.type, GDS_CORE["TransitionSignature"]))
+        assert len(sigs) == 2  # HeaterActuator, RadiatorActuator
+
+    def test_update_entries(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        entries = list(g.subjects(RDF.type, GDS_CORE["UpdateMapEntry"]))
+        assert len(entries) == 2  # temperature, radiatorAngle
+
+    def test_total_triple_count(self, satellite_model: SysMLModel) -> None:
+        g = sysml_to_rdf(satellite_model)
+        # Sanity check: should have a reasonable number of triples
+        assert len(g) > 50
+
+
+class TestRDFMinimal:
+    """Tests for RDF conversion of minimal models."""
+
+    def test_empty_model(self) -> None:
+        model = SysMLModel(name="Empty")
+        g = sysml_to_rdf(model)
+        specs = list(g.subjects(RDF.type, GDS_CORE["GDSSpec"]))
+        assert len(specs) == 1
+
+    def test_action_only_model(self) -> None:
+        from gds_sysml.parser.regex import parse_sysml
+
+        sysml = """
+        package ActionOnly {
+            @GDSPolicy
+            action def MyPolicy {
+                in port inputPort : Signal;
+                out port outputPort : Command;
+            }
+        }
+        """
+        model = parse_sysml(sysml)
+        g = sysml_to_rdf(model)
+        policies = list(g.subjects(RDF.type, GDS_CORE["Policy"]))
+        assert len(policies) == 1

--- a/packages/gds-sysml/tests/test_rdf.py
+++ b/packages/gds-sysml/tests/test_rdf.py
@@ -1,10 +1,10 @@
 """Tests for SysML model → RDF conversion."""
 
-from gds_sysml.model import SysMLModel
-from gds_sysml.rdf import sysml_to_rdf
 from rdflib import RDF
 
 from gds_owl._namespace import GDS_CORE
+from gds_sysml.model import SysMLModel
+from gds_sysml.rdf import sysml_to_rdf
 
 
 class TestRDFConversion:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ analysis = ["gds-analysis>=0.1.0"]
 psuu = ["gds-psuu>=0.1.0"]
 # Formal methods
 owl = ["gds-owl>=0.1.0"]
+# Model interchange
+sysml = ["gds-sysml>=0.1.0"]
 # Tutorials
 examples = [
     "gds-examples>=0.1.0",
@@ -67,6 +69,7 @@ all = [
     "gds-analysis>=0.1.0",
     "gds-psuu>=0.1.0",
     "gds-owl>=0.1.0",
+    "gds-sysml>=0.1.0",
     "gds-examples>=0.1.0",
 ]
 
@@ -97,6 +100,7 @@ gds-symbolic = { workspace = true }
 gds-analysis = { workspace = true }
 gds-psuu = { workspace = true }
 gds-owl = { workspace = true }
+gds-sysml = { workspace = true }
 
 [tool.uv.workspace]
 members = ["packages/*"]
@@ -113,7 +117,7 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "TCH", "RUF"]
 "packages/gds-examples/prisoners_dilemma/visualize.py" = ["E501"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["gds", "gds_viz", "ogs", "stockflow", "gds_control", "gds_software", "gds_business", "gds_sim", "gds_continuous", "gds_symbolic", "gds_psuu", "gds_owl"]
+known-first-party = ["gds", "gds_viz", "ogs", "stockflow", "gds_control", "gds_software", "gds_business", "gds_sim", "gds_continuous", "gds_symbolic", "gds_psuu", "gds_owl", "gds_sysml"]
 
 [dependency-groups]
 docs = [


### PR DESCRIPTION
Implements the initial gds-sysml package (issue #190) that provides a
SysML v2 → GDSSpec import pipeline:

- Regex-based SysML v2 parser with @GDS* annotation extraction
- SysML intermediate model (Pydantic v2 frozen models)
- SysML → GDS-core RDF conversion using gds-owl predicates
- End-to-end sysml_to_spec() pipeline: .sysml → parse → RDF → GDSSpec
- Reference satellite thermal control fixture (5 blocks, 3 state vars)
- 66 tests passing at 93% coverage

https://claude.ai/code/session_01MvFzbnki5SQG7on2gcLyZF